### PR TITLE
Infer and validate num-teams-per-arena from num-corners

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as f:
 
 install_requires = [
     'PyYAML >=3.11, <4',
-    'sr.comp.ranker >=1.0, <2',
+    'sr.comp.ranker >=1.3, <2',
     'mock >=1.0.1, <2',
     'python-dateutil >=2.2, <3'
 ]

--- a/sr/comp/comp.py
+++ b/sr/comp/comp.py
@@ -58,17 +58,17 @@ class SRComp(object):
         """A :class:`collections.OrderedDict` mapping corner numbers to
         :class:`sr.comp.arenas.Corner` objects."""
 
-        num_teams_per_arena = len(self.corners)
+        self.num_teams_per_arena = len(self.corners)
 
         scorer = load_scorer(root)
-        self.scores = scores.Scores(root, self.teams.keys(), scorer, num_teams_per_arena)
+        self.scores = scores.Scores(root, self.teams.keys(), scorer, self.num_teams_per_arena)
         """A :class:`sr.comp.scores.Scores` instance."""
 
         schedule_fname = os.path.join(root, "schedule.yaml")
         league_fname = os.path.join(root, "league.yaml")
         self.schedule = matches.MatchSchedule.create(schedule_fname,
                                                      league_fname, self.scores,
-                                                     self.arenas, num_teams_per_arena,
+                                                     self.arenas, self.num_teams_per_arena,
                                                      self.teams)
         """A :class:`sr.comp.matches.MatchSchedule` instance."""
 

--- a/sr/comp/comp.py
+++ b/sr/comp/comp.py
@@ -58,15 +58,18 @@ class SRComp(object):
         """A :class:`collections.OrderedDict` mapping corner numbers to
         :class:`sr.comp.arenas.Corner` objects."""
 
+        num_teams_per_arena = len(self.corners)
+
         scorer = load_scorer(root)
-        self.scores = scores.Scores(root, self.teams.keys(), scorer)
+        self.scores = scores.Scores(root, self.teams.keys(), scorer, num_teams_per_arena)
         """A :class:`sr.comp.scores.Scores` instance."""
 
         schedule_fname = os.path.join(root, "schedule.yaml")
         league_fname = os.path.join(root, "league.yaml")
         self.schedule = matches.MatchSchedule.create(schedule_fname,
                                                      league_fname, self.scores,
-                                                     self.arenas, self.teams)
+                                                     self.arenas, num_teams_per_arena,
+                                                     self.teams)
         """A :class:`sr.comp.matches.MatchSchedule` instance."""
 
         self.timezone = self.schedule.timezone

--- a/sr/comp/knockout_scheduler/automatic_scheduler.py
+++ b/sr/comp/knockout_scheduler/automatic_scheduler.py
@@ -20,6 +20,7 @@ class KnockoutScheduler(BaseKnockoutScheduler):
     :param schedule: The league schedule.
     :param scores: The scores.
     :param dict arenas: The arenas.
+    :param int num_teams_per_arena: The usual number of teams per arena.
     :param dict teams: The teams.
     :param config: Custom configuration for the knockout scheduler.
     """
@@ -29,11 +30,21 @@ class KnockoutScheduler(BaseKnockoutScheduler):
     Constant value due to the way the automatic seeding works.
     """
 
-    def __init__(self, schedule, scores, arenas, teams, config):
+    def __init__(self, schedule, scores, arenas, num_teams_per_arena, teams, config):
+        if num_teams_per_arena != self.num_teams_per_arena:
+            raise ValueError(
+                "The automatic knockout scheduler can only be used for {0} teams"
+                " per arena (and not {1})".format(
+                    self.num_teams_per_arena,
+                    num_teams_per_arena,
+                ),
+            )
+
         super(KnockoutScheduler, self).__init__(
             schedule,
             scores,
             arenas,
+            num_teams_per_arena,
             teams,
             config,
         )

--- a/sr/comp/knockout_scheduler/base_scheduler.py
+++ b/sr/comp/knockout_scheduler/base_scheduler.py
@@ -18,23 +18,21 @@ class BaseKnockoutScheduler(object):
     :param config: Custom configuration for the knockout scheduler.
     """
 
-    num_teams_per_arena = NotImplemented
-    """
-    The number of spaces for teams in an arena.
-
-    This is used in building matches where we don't yet know which teams will
-    actually be playing, and for filling in when there aren't enough teams to
-    fill the arena.
-
-    Derrived classes must assign an integer value for this attribute.
-    """
-
-    def __init__(self, schedule, scores, arenas, teams, config):
+    def __init__(self, schedule, scores, arenas, num_teams_per_arena, teams, config):
         self.schedule = schedule
         self.scores = scores
         self.arenas = arenas
         self.teams = teams
         self.config = config
+
+        self.num_teams_per_arena = num_teams_per_arena
+        """
+        The number of spaces for teams in an arena.
+
+        This is used in building matches where we don't yet know which teams will
+        actually be playing, and for filling in when there aren't enough teams to
+        fill the arena.
+        """
 
         # The knockout matches appear in the normal matches list
         # but this list provides them in groups of rounds.

--- a/sr/comp/knockout_scheduler/static_scheduler.py
+++ b/sr/comp/knockout_scheduler/static_scheduler.py
@@ -10,19 +10,7 @@ class StaticScheduler(BaseKnockoutScheduler):
     """
     A knockout scheduler which loads almost fixed data from the config. Assumes
     only a single arena.
-
-    :param schedule: The league schedule.
-    :param scores: The scores.
-    :param areans: The arenas.
-    :param teams: The teams.
-    :param config: Extra configuration for the static knockout.
     """
-
-    def __init__(self, schedule, scores, arenas, teams, config):
-        super(StaticScheduler, self).__init__(schedule, scores, arenas, teams,
-                                              config)
-
-        self.num_teams_per_arena = self.config['static_knockout']['teams_per_arena']
 
     def get_team(self, team_ref):
         if not self._played_all_league_matches():

--- a/tests/test_knockout_scheduler.py
+++ b/tests/test_knockout_scheduler.py
@@ -16,7 +16,7 @@ def mock_first_round_seeding(side_effect):
 
 def get_scheduler(matches = None, positions = None, \
                     knockout_positions = None, league_game_points = None, \
-                    delays = None, teams=None):
+                    delays = None, teams=None, num_teams_per_arena = 4):
     matches = matches or []
     delays = delays or []
     match_duration = timedelta(minutes = 5)
@@ -53,10 +53,18 @@ def get_scheduler(matches = None, positions = None, \
     arenas = ['A']
     if teams is None:
         teams = defaultdict(lambda: Team(None, None, False, None))
-    scheduler = KnockoutScheduler(league_schedule, scores, arenas, teams,
-                                  config)
+    scheduler = KnockoutScheduler(league_schedule, scores, arenas, num_teams_per_arena,
+                                  teams, config)
     return scheduler
 
+
+def test_invalid_num_teams_per_arena():
+    try:
+        get_scheduler(num_teams_per_arena=2)
+    except ValueError:
+        pass
+    else:
+        assert False, "Failed to raise ValueError for invalid number of teams per arena"
 
 def test_knockout_match_winners_empty():
     scheduler = get_scheduler()

--- a/tests/test_knockout_scheduler.py
+++ b/tests/test_knockout_scheduler.py
@@ -1,3 +1,4 @@
+from nose.tools import assert_raises
 
 from collections import defaultdict, OrderedDict
 from datetime import datetime, timedelta
@@ -59,12 +60,8 @@ def get_scheduler(matches = None, positions = None, \
 
 
 def test_invalid_num_teams_per_arena():
-    try:
+    with assert_raises(ValueError):
         get_scheduler(num_teams_per_arena=2)
-    except ValueError:
-        pass
-    else:
-        assert False, "Failed to raise ValueError for invalid number of teams per arena"
 
 def test_knockout_match_winners_empty():
     scheduler = get_scheduler()

--- a/tests/test_league_scores.py
+++ b/tests/test_league_scores.py
@@ -61,6 +61,7 @@ def load_datas(the_datas, teams):
             'somewhere',
             teams,
             FakeScorer,
+            num_teams_per_arena=4,
         )
         return scores
 

--- a/tests/test_matches.py
+++ b/tests/test_matches.py
@@ -76,6 +76,7 @@ def load_data(the_data):
         the_data,
         the_data['matches'],
         teams,
+        num_teams_per_arena=4,
     )
     return matches
 

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -13,7 +13,7 @@ def test_last_scored_match_none():
             ks.return_value = mock.Mock(last_scored_match = knockout_lsm)
             ts.return_value = mock.Mock(last_scored_match = tiebreaker_lsm)
 
-            scores = Scores('', None, None)
+            scores = Scores('', None, None, 0)
 
             lsm = scores.last_scored_match
             assert expected == lsm

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -109,6 +109,8 @@ def get_scheduler(matches_config, matches = None, positions = None, \
     knockout_scores = mock.Mock(resolved_positions = knockout_positions)
     scores = mock.Mock(league = league_scores, knockout = knockout_scores)
 
+    num_teams_per_arena = matches_config.pop('teams_per_arena')
+
     period_config = {
         "description": "A description of the period",
         "start_time":   datetime(2014, 3, 27,  13),
@@ -125,6 +127,7 @@ def get_scheduler(matches_config, matches = None, positions = None, \
         league_schedule,
         scores,
         arenas,
+        num_teams_per_arena,
         teams,
         config,
     )

--- a/tests/test_tiebreaker.py
+++ b/tests/test_tiebreaker.py
@@ -24,7 +24,7 @@ def make_schedule():
                 'league': { 'extra_spacing': [], },
                 'delays': []}
     teams = defaultdict(lambda: Team(None, None, False, None))
-    schedule = MatchSchedule(settings, {}, teams)
+    schedule = MatchSchedule(settings, {}, teams, 4)
 
     finals = Match(num=0, display_name='Match 0',
                    arena='A',


### PR DESCRIPTION
This add support for arenas which have a number of zones which is not four. We now infer the desired number of teams per match from the number of corners in the arena spec and use that to validate both the construction of each of the league, knockout and tiebreaker matches.