### PR TITLE
Add an API for getting the scores for a given match

### DIFF
--- a/sr/comp/scores.py
+++ b/sr/comp/scores.py
@@ -515,13 +515,13 @@ class Scores:
             MatchType.tiebreaker: self.tiebreaker,
         }[match.type]
 
-        k = (match.arena, match.num)
-        if k not in scores.game_points:
+        match_id = (match.arena, match.num)
+        if match_id not in scores.game_points:
             return None
 
         return MatchScore(
-            k,
-            game=scores.game_points[k],
-            normalised=scores.ranked_points[k],
+            match_id,
+            game=scores.game_points[match_id],
+            normalised=scores.ranked_points[match_id],
             ranking=scores.get_rankings(match),
         )

--- a/sr/comp/scores.py
+++ b/sr/comp/scores.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from collections import OrderedDict
 from functools import total_ordering
 from pathlib import Path
@@ -19,9 +20,10 @@ from typing import (
 )
 
 import league_ranker as ranker
-from league_ranker import RankedPosition
+from league_ranker import LeaguePoints, RankedPosition
 
 from . import yaml_loader
+from .match_period import Match, MatchType
 from .types import (
     GamePoints,
     MatchId,
@@ -107,6 +109,15 @@ class TeamScore:
 
     def __repr__(self) -> str:
         return f'TeamScore({self.league_points!r}, {self.game_points!r})'
+
+
+@dataclasses.dataclass(frozen=True)
+class MatchScore:
+    match_id: MatchId
+
+    game: Mapping[TLA, GamePoints]
+    normalised: Mapping[TLA, LeaguePoints]
+    ranking: Mapping[TLA, RankedPosition]
 
 
 def results_finder(root: Path) -> Iterator[Path]:
@@ -269,6 +280,16 @@ class BaseScores:
         matches = self.ranked_points.keys()
         return max(num for arena, num in matches)
 
+    def get_rankings(self, match: Match) -> Mapping[TLA, RankedPosition]:
+        """
+        Return a mapping of TLAs to ranked positions for the given match.
+
+        This is an internal API -- most consumers should use
+        ``Scores.get_scores`` instead.
+        """
+        match_id = (match.arena, match.num)
+        return degroup(self.game_positions[match_id])
+
 
 class LeagueScores(BaseScores):
     """A class which holds league scores."""
@@ -383,6 +404,20 @@ class KnockoutScores(BaseScores):
             positions = self.calculate_ranking(match_points, league_positions)
             self.resolved_positions[match_id] = positions
 
+    def get_rankings(self, match: Match) -> Mapping[TLA, RankedPosition]:
+        """
+        Return a mapping of TLAs to ranked positions for the given match.
+
+        This is an internal API -- most consumers should use
+        ``Scores.get_scores`` instead.
+        """
+
+        if match.use_resolved_ranking:
+            match_id = (match.arena, match.num)
+            return self.resolved_positions[match_id]
+
+        return super().get_rankings(match)
+
 
 class TiebreakerScores(KnockoutScores):
     pass
@@ -457,3 +492,36 @@ class Scores:
         """
         The match with the highest id for which we have score data.
         """
+
+    def get_scores(self, match: Match) -> Optional[MatchScore]:
+        """
+        Get the scores for a given match.
+
+        Parameters
+        ----------
+        match : sr.comp.match_period.Match
+            A match.
+
+        Returns
+        -------
+        MatchScore | None
+            An object describing the scores for the match, if scores have been
+            recorded yet. Otherwise None.
+        """
+
+        scores = {
+            MatchType.league: self.league,
+            MatchType.knockout: self.knockout,
+            MatchType.tiebreaker: self.tiebreaker,
+        }[match.type]
+
+        k = (match.arena, match.num)
+        if k not in scores.game_points:
+            return None
+
+        return MatchScore(
+            k,
+            game=scores.game_points[k],
+            normalised=scores.ranked_points[k],
+            ranking=scores.get_rankings(match),
+        )

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,8 +1,22 @@
+import collections
+import dataclasses
 import unittest
-from typing import Optional
+from typing import List, Mapping, Optional, Tuple
 from unittest import mock
 
-from sr.comp.scores import Scores
+from league_ranker import LeaguePoints, RankedPosition
+
+from sr.comp.match_period import MatchType
+from sr.comp.scores import (
+    KnockoutScores,
+    LeagueScores,
+    MatchScore,
+    Scores,
+    TiebreakerScores,
+)
+from sr.comp.types import ArenaName, GamePoints, MatchNumber, TLA
+
+from .factories import build_match, build_score_data, FakeScorer
 
 
 class LastScoredMatchTests(unittest.TestCase):
@@ -41,3 +55,278 @@ class LastScoredMatchTests(unittest.TestCase):
 
     def test_all_present_always_choose_tiebreaker_value_b(self) -> None:
         self.assertLastScoredMatch(42, 37, 13, 13)
+
+
+class GetScoresTests(unittest.TestCase):
+    maxDiff = 8000
+
+    def as_game_points(self, data: Mapping[str, int]) -> Mapping[TLA, GamePoints]:
+        return {TLA(x): GamePoints(y) for x, y in data.items()}
+
+    def as_normalised_points(self, data: Mapping[str, int]) -> Mapping[TLA, LeaguePoints]:
+        return {TLA(x): LeaguePoints(y) for x, y in data.items()}
+
+    def as_ranked_position(self, data: List[Tuple[str, int]]) -> Mapping[TLA, RankedPosition]:
+        return collections.OrderedDict(
+            (TLA(x), RankedPosition(y))
+            for x, y in data
+        )
+
+    def build_scores(self) -> Scores:
+        raw_league_score = build_score_data(
+            arena='A',
+            num=0,
+            scores=self.league_game,
+        )
+        raw_knockout_score = build_score_data(
+            arena='A',
+            num=3,
+            scores=self.knockout_game,
+        )
+        raw_tiebreaker_score = build_score_data(
+            arena='A',
+            num=7,
+            scores=self.tiebreaker_game,
+        )
+
+        teams = raw_league_score['teams'].keys()
+
+        league = LeagueScores(
+            [raw_league_score],
+            teams,
+            FakeScorer,
+            num_teams_per_arena=len(teams),
+        )
+        knockout = KnockoutScores(
+            [raw_knockout_score],
+            teams,
+            FakeScorer,
+            num_teams_per_arena=len(teams),
+            league_positions=league.positions,
+        )
+        tiebreaker = TiebreakerScores(
+            [raw_tiebreaker_score],
+            teams,
+            FakeScorer,
+            num_teams_per_arena=len(teams),
+            league_positions=league.positions,
+        )
+
+        return Scores(league, knockout, tiebreaker)
+
+    def get_scores(
+        self,
+        num: int,
+        arena: str,
+        type_: MatchType,
+        use_resolved_ranking: bool = False,
+    ) -> Optional[MatchScore]:
+        scores = self.build_scores()
+        return scores.get_scores(build_match(
+            num=num,
+            arena=arena,
+            type_=type_,
+            use_resolved_ranking=use_resolved_ranking,
+        ))
+
+    def assertMatchScore(self, expected: MatchScore, actual: Optional[MatchScore]) -> None:
+        self.assertIsNotNone(actual, "Should have a valid score")
+        self.assertEqual(
+            dataclasses.asdict(expected),
+            dataclasses.asdict(actual),
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.league_game = {
+            'JMS': 4,
+            'PAS': 0,
+            'RUN': 8,
+            'ICE': 2,
+        }
+        self.knockout_game = {
+            'JMS': 7,
+            'PAS': 4,
+            'RUN': 6,
+            'ICE': 3,
+        }
+        self.tiebreaker_game = {
+            'JMS': 1,
+            'PAS': 2,
+            'RUN': 3,
+            'ICE': 9,
+        }
+
+    def test_no_match(self) -> None:
+        actual = self.get_scores(num=1, arena='B', type_=MatchType.league)
+        self.assertIsNone(actual)
+
+    def test_league_match(self) -> None:
+        actual = self.get_scores(
+            num=0,
+            arena='A',
+            type_=MatchType.league,
+        )
+
+        expected = MatchScore(
+            match_id=(ArenaName('A'), MatchNumber(0)),
+            game=self.as_game_points(self.league_game),
+            normalised=self.as_normalised_points({
+                'JMS': 6,
+                'PAS': 2,
+                'RUN': 8,
+                'ICE': 4,
+            }),
+            ranking=self.as_ranked_position([
+                ('RUN', 1),
+                ('JMS', 2),
+                ('ICE', 3),
+                ('PAS', 4),
+            ]),
+        )
+        self.assertMatchScore(expected, actual)
+
+    def test_knockout_match_no_tie(self) -> None:
+        actual = self.get_scores(
+            num=3,
+            arena='A',
+            type_=MatchType.knockout,
+            use_resolved_ranking=True,
+        )
+
+        expected = MatchScore(
+            match_id=(ArenaName('A'), MatchNumber(3)),
+            game=self.as_game_points(self.knockout_game),
+            normalised=self.as_normalised_points({
+                'JMS': 8,
+                'PAS': 4,
+                'RUN': 6,
+                'ICE': 2,
+            }),
+            ranking=self.as_ranked_position([
+                ('JMS', 1),
+                ('RUN', 2),
+                ('PAS', 3),
+                ('ICE', 4),
+            ]),
+        )
+        self.assertMatchScore(expected, actual)
+
+    def test_knockout_match_tie_broke_by_league_points(self) -> None:
+        self.knockout_game = {
+            'JMS': 7,
+            'PAS': 7,
+            'RUN': 7,
+            'ICE': 7,
+        }
+
+        actual = self.get_scores(
+            num=3,
+            arena='A',
+            type_=MatchType.knockout,
+            # Knockout matches don't actually allow ties
+            use_resolved_ranking=True,
+        )
+
+        expected = MatchScore(
+            match_id=(ArenaName('A'), MatchNumber(3)),
+            game=self.as_game_points(self.knockout_game),
+            normalised=self.as_normalised_points({
+                'JMS': 5,
+                'PAS': 5,
+                'RUN': 5,
+                'ICE': 5,
+            }),
+            ranking=self.as_ranked_position([
+                ('RUN', 1),
+                ('JMS', 2),
+                ('ICE', 3),
+                ('PAS', 4),
+            ]),
+        )
+        self.assertMatchScore(expected, actual)
+
+    def test_finals_match_no_tie(self) -> None:
+        actual = self.get_scores(
+            num=3,
+            arena='A',
+            type_=MatchType.knockout,
+            use_resolved_ranking=False,
+        )
+
+        expected = MatchScore(
+            match_id=(ArenaName('A'), MatchNumber(3)),
+            game=self.as_game_points(self.knockout_game),
+            normalised=self.as_normalised_points({
+                'JMS': 8,
+                'PAS': 4,
+                'RUN': 6,
+                'ICE': 2,
+            }),
+            ranking=self.as_ranked_position([
+                ('JMS', 1),
+                ('RUN', 2),
+                ('PAS', 3),
+                ('ICE', 4),
+            ]),
+        )
+        self.assertMatchScore(expected, actual)
+
+    def test_finals_match_with_tie(self) -> None:
+        self.knockout_game = {
+            'JMS': 7,
+            'PAS': 5,
+            'RUN': 7,
+            'ICE': 5,
+        }
+
+        actual = self.get_scores(
+            num=3,
+            arena='A',
+            type_=MatchType.knockout,
+            # The final admits the possibility of a tie
+            use_resolved_ranking=False,
+        )
+
+        expected = MatchScore(
+            match_id=(ArenaName('A'), MatchNumber(3)),
+            game=self.as_game_points(self.knockout_game),
+            normalised=self.as_normalised_points({
+                'JMS': 7,
+                'PAS': 3,
+                'RUN': 7,
+                'ICE': 3,
+            }),
+            ranking=self.as_ranked_position([
+                ('JMS', 1),
+                ('RUN', 1),
+                ('ICE', 3),
+                ('PAS', 3),
+            ]),
+        )
+        self.assertMatchScore(expected, actual)
+
+    def test_tiebreaker_match(self) -> None:
+        actual = self.get_scores(
+            num=7,
+            arena='A',
+            type_=MatchType.tiebreaker,
+        )
+
+        expected = MatchScore(
+            match_id=(ArenaName('A'), MatchNumber(7)),
+            game=self.as_game_points(self.tiebreaker_game),
+            normalised=self.as_normalised_points({
+                'JMS': 2,
+                'PAS': 4,
+                'RUN': 6,
+                'ICE': 8,
+            }),
+            ranking=self.as_ranked_position([
+                ('ICE', 1),
+                ('RUN', 2),
+                ('PAS', 3),
+                ('JMS', 4),
+            ]),
+        )
+        self.assertMatchScore(expected, actual)


### PR DESCRIPTION
This intends to be logically the same as https://github.com/PeterJCLaw/srcomp-http/blob/930287a7d7c09326f55e42345a95bbee0ac64f18/sr/comp/http/query_utils.py#L81-L135

Fixes https://github.com/PeterJCLaw/srcomp/issues/11.