### PR TITLE
External sources of (league) score data

### DIFF
--- a/sr/comp/scores.py
+++ b/sr/comp/scores.py
@@ -318,8 +318,19 @@ class LeagueScores(BaseScores):
         teams: Iterable[TLA],
         scorer: ScorerType,
         num_teams_per_arena: int,
+        extra: Mapping[TLA, TeamScore] | None = None,
     ):
         super().__init__(scores_data, teams, scorer, num_teams_per_arena)
+
+        if extra:
+            for tla, score in extra.items():
+                try:
+                    team_score = self.teams[tla]
+                except KeyError:
+                    raise InvalidTeam(tla, "extra league points data") from None
+
+                team_score.add_game_points(score.game_points)
+                team_score.add_league_points(score.league_points)
 
         # Sum the league scores for each team
         for match_id, match in self.ranked_points.items():

--- a/sr/comp/scores.py
+++ b/sr/comp/scores.py
@@ -323,10 +323,10 @@ class LeagueScores(BaseScores):
 
         # Sum the league scores for each team
         for match_id, match in self.ranked_points.items():
-            for tla, score in match.items():
+            for tla, points in match.items():
                 if tla not in self.teams:
                     raise InvalidTeam(tla, "ranked score for match {}{}".format(*match_id))
-                self.teams[tla].add_league_points(score)
+                self.teams[tla].add_league_points(points)
 
         self.positions = self.rank_league(self.teams)
         r"""

--- a/sr/comp/types.py
+++ b/sr/comp/types.py
@@ -64,6 +64,17 @@ Scorer = Union[ValidatingScorer, SimpleScorer]
 ScorerType = Type[Union[ValidatingScorer, SimpleScorer]]
 
 
+class ExternalScoreData(TypedDict):
+    """
+    The expected YAML data format in "external" scores files is a single root
+    key 'scores' whose value is a list of mappings compatible with this type.
+    """
+
+    team: str
+    game_points: NotRequired[int]
+    league_points: int
+
+
 # Locations within the Venue
 
 RegionName = NewType('RegionName', str)


### PR DESCRIPTION
This creates a mechanism for additional league points (and league-section game points) to be assigned to teams at the competition. The source of these points is deliberately out of scope, allowing complete freedom for judges to merge in other sources of data.

Specifically: a new top level directory `external` may now exist, if it does then it should contain `*.yaml` files with content like:
```yaml
scores:
  - team: ABC
    league_points: 42
  - team: DEF
    game_points: 3
    league_points: 9
```
No restriction is made on the number of times the data for a team may appear in a given file, nor between files.

Fixes https://github.com/srobo/tasks/issues/973

This doesn't directly address https://github.com/PeterJCLaw/srcomp/issues/17, however may provide a way to achieve a similar outcome.

See also https://github.com/PeterJCLaw/dummy-comp/pull/1 for example data.