### PR TITLE
Improve upfront validation in the Static Knockout Scheduler

### DIFF
--- a/sr/comp/knockout_scheduler/static_scheduler.py
+++ b/sr/comp/knockout_scheduler/static_scheduler.py
@@ -93,10 +93,23 @@ class StaticScheduler(BaseKnockoutScheduler):
             ) from None
 
         try:
-            match = self.knockout_rounds[round_num][match_num]
+            knockout_round = self.knockout_rounds[round_num]
         except IndexError:
             raise InvalidReferenceError(
-                f"Reference {team_ref!r} to unscheduled match!",
+                f"Reference {team_ref!r} to unknown match round! "
+                f"(Cannot refer to round {round_num} when there are only "
+                f"{len(self.knockout_rounds)} rounds; note that round numbers "
+                "are 0-indexed)",
+            ) from None
+
+        try:
+            match = knockout_round[match_num]
+        except IndexError:
+            raise InvalidReferenceError(
+                f"Reference {team_ref!r} to unknown match! "
+                f"(Cannot refer to round {match_num} when there are only "
+                f"{len(knockout_round)} matches in round {round_num}; note that "
+                "match numbers are 0-indexed)",
             ) from None
 
         try:
@@ -104,7 +117,8 @@ class StaticScheduler(BaseKnockoutScheduler):
             return ranking[pos]
         except IndexError:
             raise InvalidReferenceError(
-                f"Reference {team_ref!r} to invalid ranking!",
+                f"Reference {team_ref!r} to invalid ranking! "
+                f"(Position {pos!r} does not exist in match \"{match.display_name}\")",
             ) from None
 
     def _add_match(

--- a/sr/comp/knockout_scheduler/static_scheduler.py
+++ b/sr/comp/knockout_scheduler/static_scheduler.py
@@ -42,15 +42,16 @@ class StaticScheduler(BaseKnockoutScheduler):
         super().__init__(*args, **kwargs)
 
         # Collect a list of the teams eligible for the knockouts, in seeded order.
+        # TODO: deduplicate this vs similar logic in the automated scheduler.
         last_league_match_num = self.schedule.n_matches()
-        self._knockout_seeds = self._get_non_dropped_out_teams(
+        teams = self._get_non_dropped_out_teams(
             MatchNumber(last_league_match_num),
         )
+        if not self._played_all_league_matches():
+            teams = [UNKNOWABLE_TEAM] * len(teams)
+        self._knockout_seeds = teams
 
     def get_team(self, team_ref: StaticMatchTeamReference | None) -> TLA | None:
-        if not self._played_all_league_matches():
-            return UNKNOWABLE_TEAM
-
         if team_ref is None:
             return None
 

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -7,6 +7,8 @@ from sr.comp.knockout_scheduler import StaticScheduler, UNKNOWABLE_TEAM
 from sr.comp.match_period import Match, MatchType
 from sr.comp.teams import Team
 
+from .factories import build_match
+
 TLAs = ['AAA', 'BBB', 'CCC', 'DDD', 'EEE', 'FFF', 'GGG', 'HHH', 'III', 'JJJ']
 
 
@@ -204,6 +206,19 @@ class StaticKnockoutSchedulerTests(unittest.TestCase):
             a = period.matches[i]
 
             self.assertEqual(e, a, f"Match {i} in the knockouts")
+
+    def assertInvalidReference(self, value, matches=()):
+        config = get_four_team_config()
+
+        config['matches'][1][0]['teams'][0] = value
+
+        with self.assertRaises(ValueError):
+            scheduler = get_scheduler(
+                matches_config=config,
+                matches=matches,
+            )
+
+            scheduler.add_knockouts()
 
     def test_four_teams_before(self):
         # Add an un-scored league match so that we don't appear to have played them all
@@ -448,3 +463,43 @@ class StaticKnockoutSchedulerTests(unittest.TestCase):
                 ]),
             },
         )
+
+    def test_invalid_position_reference(self):
+        self.assertInvalidReference('005')
+
+    def test_invalid_match_reference(self):
+        self.assertInvalidReference('050')
+
+    def test_invalid_round_reference(self):
+        self.assertInvalidReference('500')
+
+    def test_invalid_seed_reference_low(self):
+        self.assertInvalidReference('S0')
+
+    def test_invalid_seed_reference_high(self):
+        self.assertInvalidReference('S9999')
+
+    def test_invalid_position_reference_incomplete_league(self):
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{'A': build_match(arena='A')}]
+        self.assertInvalidReference('005', matches=league_matches)
+
+    def test_invalid_match_reference_incomplete_league(self):
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{'A': build_match(arena='A')}]
+        self.assertInvalidReference('050', matches=league_matches)
+
+    def test_invalid_round_reference_incomplete_league(self):
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{'A': build_match(arena='A')}]
+        self.assertInvalidReference('500', matches=league_matches)
+
+    def test_invalid_seed_reference_low_incomplete_league(self):
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{'A': build_match(arena='A')}]
+        self.assertInvalidReference('S0', matches=league_matches)
+
+    def test_invalid_seed_reference_high_incomplete_league(self):
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{'A': build_match(arena='A')}]
+        self.assertInvalidReference('S9999', matches=league_matches)

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -7,6 +7,7 @@ from sr.comp.knockout_scheduler import StaticScheduler, UNKNOWABLE_TEAM
 from sr.comp.knockout_scheduler.static_scheduler import (
     InvalidReferenceError,
     InvalidSeedError,
+    WrongNumberOfTeamsError,
 )
 from sr.comp.match_period import Match, MatchType
 from sr.comp.teams import Team
@@ -520,3 +521,45 @@ class StaticKnockoutSchedulerTests(unittest.TestCase):
         # Add an un-scored league match so that we don't appear to have played them all
         league_matches = [{'A': build_match(arena='A')}]
         self.assertInvalidSeed('S9999', matches=league_matches)
+
+    def test_too_few_teams_first_round(self):
+        config = get_four_team_config()
+
+        config['matches'][0][0]['teams'].pop()
+
+        self.assertInvalidSchedule(config, WrongNumberOfTeamsError)
+
+    def test_too_few_teams_second_round(self):
+        config = get_four_team_config()
+
+        config['matches'][1][0]['teams'].pop()
+
+        self.assertInvalidSchedule(config, WrongNumberOfTeamsError)
+
+    def test_too_few_teams_third_round(self):
+        config = get_four_team_config()
+
+        config['matches'][2][0]['teams'].pop()
+
+        self.assertInvalidSchedule(config, WrongNumberOfTeamsError)
+
+    def test_too_many_teams_first_round(self):
+        config = get_four_team_config()
+
+        config['matches'][0][0]['teams'].append('S1')
+
+        self.assertInvalidSchedule(config, WrongNumberOfTeamsError)
+
+    def test_too_many_teams_second_round(self):
+        config = get_four_team_config()
+
+        config['matches'][1][0]['teams'].append('S1')
+
+        self.assertInvalidSchedule(config, WrongNumberOfTeamsError)
+
+    def test_too_many_teams_third_round(self):
+        config = get_four_team_config()
+
+        config['matches'][2][0]['teams'].append('S1')
+
+        self.assertInvalidSchedule(config, WrongNumberOfTeamsError)


### PR DESCRIPTION
Fixes #6.

Previously there were various forms of input which wouldn't be validated, or where the input validation was implicit and resulted in unclear error messages. This changes that such that the validations are more explicit, have better messages and generally move checks upfront.