### PR TITLE
Add support for hooking the league points calculation

### DIFF
--- a/sr/comp/ranker.py
+++ b/sr/comp/ranker.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Collection, Mapping
+
+import league_ranker
+from league_ranker import LeaguePoints, RankedPosition, TZone
+
+from .types import MatchId, Ranker
+
+
+class LeagueRanker(Ranker):
+    """
+    Default implementation of a ranker class, wrapping `league-ranker`.
+    """
+
+    def calc_ranked_points(
+        self,
+        positions: Mapping[RankedPosition, Collection[TZone]],
+        *,
+        disqualifications: Collection[TZone],
+        num_zones: int,
+        match_id: MatchId,
+    ) -> dict[TZone, LeaguePoints]:
+        return league_ranker.calc_ranked_points(
+            positions,
+            disqualifications,
+            num_zones,
+        )

--- a/sr/comp/types.py
+++ b/sr/comp/types.py
@@ -2,8 +2,18 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import Any, NewType, Protocol, runtime_checkable, TypedDict, Union
+from typing import (
+    Any,
+    Collection,
+    NewType,
+    Protocol,
+    runtime_checkable,
+    TypedDict,
+    Union,
+)
 from typing_extensions import NotRequired
+
+from league_ranker import LeaguePoints, RankedPosition, TZone
 
 TLA = NewType('TLA', str)
 
@@ -75,6 +85,34 @@ class ExternalScoreData(TypedDict):
     game_points: NotRequired[int]
     league_points: int
 
+
+class Ranker(Protocol):
+    """
+    Computes ranking information related to the league.
+
+    This is part of providing a hook point for customising the league points
+    behaviour. Initially this only supports changing the behaviour of the points
+    returned, though we may extend this in future to support other functionality
+    currently directly tied to the `league-ranker` package, such as position
+    calculation.
+    """
+
+    def calc_ranked_points(
+        self,
+        positions: Mapping[RankedPosition, Collection[TZone]],
+        *,
+        disqualifications: Collection[TZone],
+        num_zones: int,
+        match_id: MatchId,
+    ) -> dict[TZone, LeaguePoints]:
+        """
+        Equivalent to `league_ranker.calc_ranked_points`, though with clearer
+        argument names and accepting a match id value to enable customisation.
+        """
+        ...
+
+
+RankerType = type[Ranker]
 
 # Locations within the Venue
 

--- a/tests/test_league_scores.py
+++ b/tests/test_league_scores.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 from collections.abc import Iterable, Mapping
 
+from sr.comp.ranker import LeagueRanker
 from sr.comp.scores import LeagueScores, TeamScore
 from sr.comp.types import ScoreData, TLA
 
@@ -26,6 +27,7 @@ def load_datas(
         the_datas,
         teams,
         FakeScorer,
+        LeagueRanker,
         num_teams_per_arena=4,
         extra=extra,
     )

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+from sr.comp.comp import load_ranker
+
+SIMPLE_RANKER = """
+class Ranker:
+    def calc_ranked_points(self, positions, disqualifications, num_zones, match_id):
+        raise NotImplementedError
+"""
+
+ATTR_TEMPLATE = """
+    {attr} = {value}
+"""
+
+
+class RankerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addClassCleanup(temp_dir.cleanup)
+        self.temp_dir = Path(temp_dir.name)
+
+    def test_ranker_imported(self) -> None:
+        ranker_py = self.temp_dir / 'scoring' / 'ranker.py'
+        ranker_py.parent.mkdir(exist_ok=True, parents=True)
+
+        test_id = str(uuid.uuid4())
+        ranker_py.write_text(
+            SIMPLE_RANKER + ATTR_TEMPLATE.format(
+                attr='testing_attr',
+                value=repr(test_id),
+            ),
+        )
+
+        ranker_class = load_ranker(self.temp_dir)
+        self.assertEqual(
+            ranker_class.testing_attr,  # type: ignore[attr-defined]
+            test_id,
+        )
+
+    def test_warns_unexpected_attr(self) -> None:
+        ranker_py = self.temp_dir / 'scoring' / 'ranker.py'
+        ranker_py.parent.mkdir(exist_ok=True, parents=True)
+
+        ranker_py.write_text(
+            SIMPLE_RANKER + ATTR_TEMPLATE.format(
+                attr='calc_positions',
+                value='any',
+            ),
+        )
+
+        with self.assertWarnsRegex(
+            FutureWarning,
+            ".*'calc_positions'.* part of the API in future",
+        ):
+            ranker_class = load_ranker(self.temp_dir)
+
+        self.assertIsNotNone(ranker_class)

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -9,6 +9,7 @@ from unittest import mock
 from league_ranker import LeaguePoints, RankedPosition
 
 from sr.comp.match_period import MatchType
+from sr.comp.ranker import LeagueRanker
 from sr.comp.scores import (
     KnockoutScores,
     LeagueScores,
@@ -97,12 +98,14 @@ class GetScoresTests(unittest.TestCase):
             [raw_league_score],
             teams,
             FakeScorer,
+            LeagueRanker,
             num_teams_per_arena=len(teams),
         )
         knockout = KnockoutScores(
             [raw_knockout_score],
             teams,
             FakeScorer,
+            LeagueRanker,
             num_teams_per_arena=len(teams),
             league_positions=league.positions,
         )
@@ -110,6 +113,7 @@ class GetScoresTests(unittest.TestCase):
             [raw_tiebreaker_score],
             teams,
             FakeScorer,
+            LeagueRanker,
             num_teams_per_arena=len(teams),
             league_positions=league.positions,
         )


### PR DESCRIPTION
This takes the path of providing the start of a mechanism to replace aspects of the league-ranker logic, leaving the door open to extending this further in future.

Fixes https://github.com/PeterJCLaw/srcomp/issues/37.