### PR TITLE
Support static knockout rounds, matches & positions > 9

### DIFF
--- a/sr/comp/knockout_scheduler/static_scheduler.py
+++ b/sr/comp/knockout_scheduler/static_scheduler.py
@@ -13,6 +13,18 @@ from ..types import ArenaName, MatchNumber, TLA
 from .base_scheduler import BaseKnockoutScheduler, UNKNOWABLE_TEAM
 
 StaticMatchTeamReference = NewType('StaticMatchTeamReference', str)
+StaticMatchTeamReference.__doc__ = r"""
+A logical reference to a team for pulling into a knockout match.
+
+This supports the following formats:
+ - 'S\d+': A seeded team, pulled from the results of the league stage.
+ - '\d{3}': A reference to a tie-resolved rank in the results of another match
+   within the knockout. The first digit refers to the round number, the second
+   to the match number within that round and the last to the rank within the
+   results of that match to look for a team. All of these are 0-indexed, so
+   '000' is the winner of the first match from the first knockouts round. Ties
+   are resolved using the standard league position logic.
+"""
 
 
 class InvalidSeedError(ValueError):

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -497,6 +497,9 @@ class StaticKnockoutSchedulerTests(unittest.TestCase):
     def test_invalid_seed_reference_high(self):
         self.assertInvalidSeed('S9999')
 
+    def test_invalid_reference_other_text(self):
+        self.assertInvalidReference('bees')
+
     def test_invalid_position_reference_incomplete_league(self):
         # Add an un-scored league match so that we don't appear to have played them all
         league_matches = [{'A': build_match(arena='A')}]

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -7,6 +7,7 @@ from sr.comp.knockout_scheduler import StaticScheduler, UNKNOWABLE_TEAM
 from sr.comp.knockout_scheduler.static_scheduler import (
     InvalidReferenceError,
     InvalidSeedError,
+    parse_team_ref,
     WrongNumberOfTeamsError,
 )
 from sr.comp.match_period import Match, MatchType
@@ -211,6 +212,17 @@ class StaticKnockoutSchedulerTests(unittest.TestCase):
             a = period.matches[i]
 
             self.assertEqual(e, a, f"Match {i} in the knockouts")
+
+    def assertParseInvalidReference(self, value: str) -> None:
+        with self.assertRaises(InvalidReferenceError):
+            parse_team_ref(value)
+
+    def assertParseReference(self, expected: tuple[int, int, int], value: str) -> None:
+        self.assertEqual(
+            expected,
+            parse_team_ref(value),
+            f"Wrong result from parsing {value!r}",
+        )
 
     def assertInvalidReference(self, value, matches=()):
         config = get_four_team_config()
@@ -477,6 +489,36 @@ class StaticKnockoutSchedulerTests(unittest.TestCase):
                     ('FFF', 2),
                 ]),
             },
+        )
+
+    def test_parse_team_ref_invalid_short(self):
+        self.assertParseInvalidReference('00')
+
+    def test_parse_team_ref_invalid_long(self):
+        self.assertParseInvalidReference('00')
+
+    def test_parse_team_ref_invalid_not_digits(self):
+        self.assertParseInvalidReference('bee')
+
+    def test_parse_team_ref_invalid_rmp_not_digits(self):
+        self.assertParseInvalidReference('R_M_P_')
+
+    def test_parse_team_ref_legacy(self):
+        self.assertParseReference(
+            (1, 2, 3),
+            '123',
+        )
+
+    def test_parse_team_ref_rmp(self):
+        self.assertParseReference(
+            (1, 2, 3),
+            'R1M2P3',
+        )
+
+    def test_parse_team_ref_rmp_long(self):
+        self.assertParseReference(
+            (10, 20, 30),
+            'R10M20P30',
         )
 
     def test_improper_position_reference(self):


### PR DESCRIPTION
Previously the static knockout scheduler relied on the input string being exactly three characters, which in turn forced the indices of the rounds, matches & positions being referred to to single digits. This was historically not an issue, however for SR2025 we're exploring a double-elimination knockout which needs more than 10 rounds.

This adds support for that by introducing a format which does not rely on the number of characters in the input.

The interesting part here is in the third commit.