### PR TITLE
Move to the hookable position ranking being a plain function

### DIFF
--- a/sr/comp/ranker.py
+++ b/sr/comp/ranker.py
@@ -5,24 +5,21 @@ from typing import Collection, Mapping
 import league_ranker
 from league_ranker import LeaguePoints, RankedPosition, TZone
 
-from .types import MatchId, Ranker
+from .types import MatchId
 
 
-class LeagueRanker(Ranker):
+def default_calc_ranked_points(
+    positions: Mapping[RankedPosition, Collection[TZone]],
+    *,
+    disqualifications: Collection[TZone],
+    num_zones: int,
+    match_id: MatchId,
+) -> dict[TZone, LeaguePoints]:
     """
-    Default implementation of a ranker class, wrapping `league-ranker`.
+    Default implementation of `CalcRankedPointsHook`, wrapping `league-ranker`.
     """
-
-    def calc_ranked_points(
-        self,
-        positions: Mapping[RankedPosition, Collection[TZone]],
-        *,
-        disqualifications: Collection[TZone],
-        num_zones: int,
-        match_id: MatchId,
-    ) -> dict[TZone, LeaguePoints]:
-        return league_ranker.calc_ranked_points(
-            positions,
-            disqualifications,
-            num_zones,
-        )
+    return league_ranker.calc_ranked_points(
+        positions,
+        disqualifications,
+        num_zones,
+    )

--- a/sr/comp/types.py
+++ b/sr/comp/types.py
@@ -86,18 +86,19 @@ class ExternalScoreData(TypedDict):
     league_points: int
 
 
-class Ranker(Protocol):
+class CalcRankedPointsHook(Protocol):
     """
     Computes ranking information related to the league.
 
-    This is part of providing a hook point for customising the league points
-    behaviour. Initially this only supports changing the behaviour of the points
+    This is a hook point for customising the league points behaviour.
+
+    Initially this hooking only supports changing the behaviour of the points
     returned, though we may extend this in future to support other functionality
     currently directly tied to the `league-ranker` package, such as position
     calculation.
     """
 
-    def calc_ranked_points(
+    def __call__(
         self,
         positions: Mapping[RankedPosition, Collection[TZone]],
         *,
@@ -111,8 +112,6 @@ class Ranker(Protocol):
         """
         ...
 
-
-RankerType = type[Ranker]
 
 # Locations within the Venue
 

--- a/tests/test_league_scores.py
+++ b/tests/test_league_scores.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import unittest
 from collections.abc import Iterable, Mapping
 
-from sr.comp.ranker import LeagueRanker
+from sr.comp.ranker import default_calc_ranked_points
 from sr.comp.scores import LeagueScores, TeamScore
 from sr.comp.types import ScoreData, TLA
 
@@ -27,7 +27,7 @@ def load_datas(
         the_datas,
         teams,
         FakeScorer,
-        LeagueRanker,
+        default_calc_ranked_points,
         num_teams_per_arena=4,
         extra=extra,
     )

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -8,13 +8,12 @@ from pathlib import Path
 from sr.comp.comp import load_ranker
 
 SIMPLE_RANKER = """
-class Ranker:
-    def calc_ranked_points(self, positions, disqualifications, num_zones, match_id):
-        raise NotImplementedError
+def calc_ranked_points(positions, disqualifications, num_zones, match_id):
+    raise NotImplementedError
 """
 
 ATTR_TEMPLATE = """
-    {attr} = {value}
+{attr} = {value}
 """
 
 
@@ -33,7 +32,7 @@ class RankerTests(unittest.TestCase):
         test_id = str(uuid.uuid4())
         ranker_py.write_text(
             SIMPLE_RANKER + ATTR_TEMPLATE.format(
-                attr='testing_attr',
+                attr='calc_ranked_points.testing_attr',
                 value=repr(test_id),
             ),
         )

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -9,7 +9,7 @@ from unittest import mock
 from league_ranker import LeaguePoints, RankedPosition
 
 from sr.comp.match_period import MatchType
-from sr.comp.ranker import LeagueRanker
+from sr.comp.ranker import default_calc_ranked_points
 from sr.comp.scores import (
     KnockoutScores,
     LeagueScores,
@@ -98,14 +98,14 @@ class GetScoresTests(unittest.TestCase):
             [raw_league_score],
             teams,
             FakeScorer,
-            LeagueRanker,
+            default_calc_ranked_points,
             num_teams_per_arena=len(teams),
         )
         knockout = KnockoutScores(
             [raw_knockout_score],
             teams,
             FakeScorer,
-            LeagueRanker,
+            default_calc_ranked_points,
             num_teams_per_arena=len(teams),
             league_positions=league.positions,
         )
@@ -113,7 +113,7 @@ class GetScoresTests(unittest.TestCase):
             [raw_tiebreaker_score],
             teams,
             FakeScorer,
-            LeagueRanker,
+            default_calc_ranked_points,
             num_teams_per_arena=len(teams),
             league_positions=league.positions,
         )


### PR DESCRIPTION
This presents a potentially slightly cleaner interface for the simple cases, though it does make re-use of the base case within a compstate slightly more cumbersome (as more imports would be needed if we add more hooks).

See https://github.com/srobo/sr2025-comp/pull/11 for how this changes the compstate implementation.