### PR TITLE
Add support for knockout structure & brackets

### DIFF
--- a/sr/comp/knockout_scheduler/__init__.py
+++ b/sr/comp/knockout_scheduler/__init__.py
@@ -3,10 +3,11 @@
 from .automatic_scheduler import AutoKnockoutScheduleData, KnockoutScheduler
 from .base_scheduler import UNKNOWABLE_TEAM
 from .static_scheduler import StaticKnockoutScheduleData, StaticScheduler
-from .types import KnockoutRound
+from .types import KnockoutBracket, KnockoutRound
 
 __all__ = (
     'AutoKnockoutScheduleData',
+    'KnockoutBracket',
     'KnockoutRound',
     'KnockoutScheduler',
     'StaticKnockoutScheduleData',

--- a/sr/comp/knockout_scheduler/automatic_scheduler.py
+++ b/sr/comp/knockout_scheduler/automatic_scheduler.py
@@ -6,7 +6,7 @@ import datetime
 import math
 from collections.abc import Iterable, Mapping, Sized
 
-from ..match_period import Match, MatchSlot, MatchType
+from ..match_period import KnockoutMatch, Match, MatchSlot, MatchType
 from ..match_period_clock import MatchPeriodClock, OutOfTimeException
 from ..scores import Scores
 from ..teams import Team
@@ -104,7 +104,7 @@ class KnockoutScheduler(BaseKnockoutScheduler[AutoKnockoutScheduleData]):
                     num,
                 )
 
-                match = Match(
+                match = KnockoutMatch(
                     num,
                     display_name,
                     arena,
@@ -112,6 +112,7 @@ class KnockoutScheduler(BaseKnockoutScheduler[AutoKnockoutScheduleData]):
                     start_time,
                     end_time,
                     MatchType.knockout,
+                    knockout_bracket='default',
                     # Just the finals don't use the resolved ranking
                     use_resolved_ranking=rounds_remaining != 0,
                 )

--- a/sr/comp/knockout_scheduler/automatic_scheduler.py
+++ b/sr/comp/knockout_scheduler/automatic_scheduler.py
@@ -12,7 +12,11 @@ from ..scores import Scores
 from ..teams import Team
 from ..types import ArenaName, KnockoutConfigData, MatchNumber, TLA
 from . import seeding, stable_random
-from .base_scheduler import BaseKnockoutScheduleData, BaseKnockoutScheduler
+from .base_scheduler import (
+    BaseKnockoutScheduleData,
+    BaseKnockoutScheduler,
+    DEFAULT_KNOCKOUT_BRACKET_NAME,
+)
 from .types import ScheduleHost
 
 
@@ -112,7 +116,7 @@ class KnockoutScheduler(BaseKnockoutScheduler[AutoKnockoutScheduleData]):
                     start_time,
                     end_time,
                     MatchType.knockout,
-                    knockout_bracket='default',
+                    knockout_bracket=DEFAULT_KNOCKOUT_BRACKET_NAME,
                     # Just the finals don't use the resolved ranking
                     use_resolved_ranking=rounds_remaining != 0,
                 )

--- a/sr/comp/knockout_scheduler/base_scheduler.py
+++ b/sr/comp/knockout_scheduler/base_scheduler.py
@@ -21,6 +21,8 @@ class BaseKnockoutScheduleData(TypedDict):
 
 TConfig = TypeVar('TConfig', bound=BaseKnockoutScheduleData)
 
+DEFAULT_KNOCKOUT_BRACKET_NAME = 'default'
+
 
 class BaseKnockoutScheduler(Generic[TConfig]):
     """

--- a/sr/comp/knockout_scheduler/base_scheduler.py
+++ b/sr/comp/knockout_scheduler/base_scheduler.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Generic, TypedDict, TypeVar
 
 from ..match_period import Match, MatchPeriod, MatchType
 from ..scores import Scores
 from ..teams import Team
-from ..types import ArenaName, MatchId, MatchNumber, TLA
-from .types import KnockoutPeriodData, KnockoutRound, ScheduleHost
+from ..types import ArenaName, KnockoutBracketData, MatchId, MatchNumber, TLA
+from .types import (
+    KnockoutBracket,
+    KnockoutPeriodData,
+    KnockoutRound,
+    ScheduleHost,
+)
 
 # Use '???' as the "we don't know yet" marker
 UNKNOWABLE_TEAM = TLA('???')
@@ -17,6 +22,7 @@ UNKNOWABLE_TEAM = TLA('???')
 
 class BaseKnockoutScheduleData(TypedDict):
     match_periods: KnockoutPeriodData
+    brackets: Sequence[KnockoutBracketData]
 
 
 TConfig = TypeVar('TConfig', bound=BaseKnockoutScheduleData)
@@ -34,6 +40,18 @@ class BaseKnockoutScheduler(Generic[TConfig]):
     :param dict teams: The teams.
     :param config: Custom configuration for the knockout scheduler.
     """
+
+    @staticmethod
+    def _build_brackets(brackets: Sequence[KnockoutBracketData]) -> list[KnockoutBracket]:
+        if not brackets:
+            return [
+                KnockoutBracket(
+                    DEFAULT_KNOCKOUT_BRACKET_NAME,
+                    display_name="Knockouts",
+                ),
+            ]
+
+        return [KnockoutBracket(**x) for x in brackets]
 
     def __init__(
         self,
@@ -57,6 +75,14 @@ class BaseKnockoutScheduler(Generic[TConfig]):
         This is used in building matches where we don't yet know which teams will
         actually be playing, and for filling in when there aren't enough teams to
         fill the arena.
+        """
+
+        self.knockout_brackets = self._build_brackets(self.config['brackets'])
+        """
+        Brackets which make up the knockout.
+
+        This currently has no bearing on the actual matches and is purely a
+        display consideration.
         """
 
         # The knockout matches appear in the normal matches list

--- a/sr/comp/knockout_scheduler/static_scheduler.py
+++ b/sr/comp/knockout_scheduler/static_scheduler.py
@@ -21,7 +21,11 @@ from ..types import (
     StaticMatchTeamReference,
     TLA,
 )
-from .base_scheduler import BaseKnockoutScheduleData, BaseKnockoutScheduler
+from .base_scheduler import (
+    BaseKnockoutScheduleData,
+    BaseKnockoutScheduler,
+    DEFAULT_KNOCKOUT_BRACKET_NAME,
+)
 from .types import ScheduleHost
 
 
@@ -223,7 +227,7 @@ class StaticScheduler(BaseKnockoutScheduler[StaticKnockoutScheduleData]):
             end_time,
             MatchType.knockout,
             use_resolved_ranking=not is_final,
-            knockout_bracket=match_info.get('bracket', 'default'),
+            knockout_bracket=match_info.get('bracket', DEFAULT_KNOCKOUT_BRACKET_NAME),
         )
         self.knockout_rounds[-1].append(match)
 

--- a/sr/comp/knockout_scheduler/static_scheduler.py
+++ b/sr/comp/knockout_scheduler/static_scheduler.py
@@ -8,7 +8,7 @@ import re
 import typing
 from collections.abc import Iterable, Mapping
 
-from ..match_period import Match, MatchSlot, MatchType
+from ..match_period import KnockoutMatch, MatchSlot, MatchType
 from ..scores import Scores
 from ..teams import Team
 from ..types import (
@@ -214,7 +214,7 @@ class StaticScheduler(BaseKnockoutScheduler[StaticKnockoutScheduleData]):
             display_name = f"{override_name} (#{num})"
 
         is_final = rounds_remaining == 0
-        match = Match(
+        match = KnockoutMatch(
             num,
             display_name,
             arena,
@@ -223,6 +223,7 @@ class StaticScheduler(BaseKnockoutScheduler[StaticKnockoutScheduleData]):
             end_time,
             MatchType.knockout,
             use_resolved_ranking=not is_final,
+            knockout_bracket=match_info.get('bracket', 'default'),
         )
         self.knockout_rounds[-1].append(match)
 

--- a/sr/comp/knockout_scheduler/types.py
+++ b/sr/comp/knockout_scheduler/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import datetime
 from collections.abc import Collection, Iterable
 from typing import Protocol, TypedDict
@@ -24,6 +25,12 @@ class ScheduleHost(Protocol):
     @property
     def n_league_matches(self) -> int:
         ...
+
+
+@dataclasses.dataclass
+class KnockoutBracket:
+    name: str
+    display_name: str
 
 
 class KnockoutPeriodData(TypedDict):

--- a/sr/comp/match_period.py
+++ b/sr/comp/match_period.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 from collections.abc import Mapping
 from enum import Enum, unique
-from typing import NamedTuple, NewType
+from typing import NewType
 
 from .types import ArenaName, MatchNumber, TLA
 
 
-class Delay(NamedTuple):
+@dataclasses.dataclass(frozen=True, slots=True)
+class Delay:
     delay: datetime.timedelta
     time: datetime.datetime
 
@@ -22,7 +24,8 @@ class MatchType(Enum):
     tiebreaker = 'tiebreaker'
 
 
-class Match(NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class Match:
     num: MatchNumber
     display_name: str
     arena: ArenaName
@@ -36,7 +39,8 @@ class Match(NamedTuple):
 MatchSlot = NewType('MatchSlot', Mapping[ArenaName, Match])
 
 
-class MatchPeriod(NamedTuple):
+@dataclasses.dataclass(frozen=True, slots=True)
+class MatchPeriod:
     start_time: datetime.datetime
     end_time: datetime.datetime
     max_end_time: datetime.datetime

--- a/sr/comp/match_period.py
+++ b/sr/comp/match_period.py
@@ -6,7 +6,7 @@ import dataclasses
 import datetime
 from collections.abc import Mapping
 from enum import Enum, unique
-from typing import NewType
+from typing import Literal, NewType
 
 from .types import ArenaName, MatchNumber, TLA
 
@@ -34,6 +34,12 @@ class Match:
     end_time: datetime.datetime
     type: MatchType  # noqa:A003
     use_resolved_ranking: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class KnockoutMatch(Match):
+    type: Literal[MatchType.knockout]  # noqa:A003
+    knockout_bracket: str
 
 
 MatchSlot = NewType('MatchSlot', Mapping[ArenaName, Match])

--- a/sr/comp/matches.py
+++ b/sr/comp/matches.py
@@ -15,6 +15,7 @@ from . import yaml_loader
 from .arenas import Arena
 from .knockout_scheduler import (
     AutoKnockoutScheduleData,
+    KnockoutBracket,
     KnockoutRound,
     KnockoutScheduler,
     StaticKnockoutScheduleData,
@@ -148,6 +149,7 @@ class MatchSchedule:
                 teams,
                 config=StaticKnockoutScheduleData({
                     'match_periods': y['match_periods'],
+                    'brackets': y['knockout'].get('brackets', ()),
                     'static_knockout': StaticScheduler.modernise_config_if_needed(
                         y['static_knockout'],
                     ),
@@ -162,12 +164,14 @@ class MatchSchedule:
                 teams,
                 config=AutoKnockoutScheduleData({
                     'match_periods': y['match_periods'],
+                    'brackets': y['knockout'].get('brackets', ()),
                     'knockout': y['knockout'],
                 }),
             )
 
         k.add_knockouts()
 
+        schedule.knockout_brackets = k.knockout_brackets
         schedule.knockout_rounds = k.knockout_rounds
         schedule.match_periods.append(k.period)
 
@@ -192,6 +196,14 @@ class MatchSchedule:
         r"""
         A list of the :class:`.MatchPeriod`\s which contain the matches
         for the competition.
+        """
+
+        self.knockout_brackets: Sequence[KnockoutBracket]
+        """
+        A list of brackets which make up the knockout.
+
+        This currently has no bearing on the actual matches and is purely a
+        display consideration.
         """
 
         self.knockout_rounds: Sequence[KnockoutRound] = []

--- a/sr/comp/types.py
+++ b/sr/comp/types.py
@@ -246,6 +246,14 @@ class KnockoutSingleArenaData(TypedDict):
     arenas: list[ArenaName]
 
 
+class KnockoutBracketData(TypedDict):
+    name: str
+    """The internal identifier of a knockout bracket"""
+
+    display_name: str
+    """The internal identifier of a knockout bracket"""
+
+
 class KnockoutConfigData(TypedDict):
     round_spacing: int
     """Time delay between rounds (in seconds)"""
@@ -254,6 +262,15 @@ class KnockoutConfigData(TypedDict):
     arity: NotRequired[int]
     """Number of teams taking part"""
     single_arena: KnockoutSingleArenaData
+
+    brackets: NotRequired[list[KnockoutBracketData]]
+    """
+    Brackets which make up the knockout.
+
+    When omitted a single bracket named 'default' with display name "Knockouts" is used.
+
+    This currently has no bearing on the actual matches and is purely a display consideration.
+    """
 
     static: NotRequired[bool]
     """Whether or not to use the static knockout scheduler (rather than the automatic one)"""

--- a/sr/comp/types.py
+++ b/sr/comp/types.py
@@ -281,6 +281,7 @@ class StaticMatchInfo(TypedDict):
     start_time: datetime.datetime
     teams: list[StaticMatchTeamReference]
     display_name: NotRequired[str]
+    bracket: NotRequired[str]
 
 
 class StaticKnockoutRoundData(TypedDict):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,6 +5,9 @@ import random
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import TypeVar
 
+from sr.comp.knockout_scheduler.base_scheduler import (
+    DEFAULT_KNOCKOUT_BRACKET_NAME,
+)
 from sr.comp.match_period import (
     Delay,
     KnockoutMatch,
@@ -46,7 +49,7 @@ def build_match(
             end_time,
             type_,
             use_resolved_ranking,
-            knockout_bracket or 'default',
+            knockout_bracket or DEFAULT_KNOCKOUT_BRACKET_NAME,
         )
     elif knockout_bracket is not None:
         raise TypeError("Should not provide 'knockout_bracket' for non-knockout match")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,7 +5,13 @@ import random
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import TypeVar
 
-from sr.comp.match_period import Delay, Match, MatchSlot, MatchType
+from sr.comp.match_period import (
+    Delay,
+    KnockoutMatch,
+    Match,
+    MatchSlot,
+    MatchType,
+)
 from sr.comp.types import (
     ArenaName,
     GamePoints,
@@ -28,7 +34,23 @@ def build_match(
     end_time: datetime.datetime = datetime.datetime(2020, 1, 25, 11, 5, tzinfo=UTC),
     type_: MatchType = MatchType.league,
     use_resolved_ranking: bool = False,
+    knockout_bracket: str | None = None,
 ) -> Match:
+    if type_ == MatchType.knockout:
+        return KnockoutMatch(
+            MatchNumber(num),
+            f"Match {num}",
+            ArenaName(arena),
+            list(teams),
+            start_time,
+            end_time,
+            type_,
+            use_resolved_ranking,
+            knockout_bracket or 'default',
+        )
+    elif knockout_bracket is not None:
+        raise TypeError("Should not provide 'knockout_bracket' for non-knockout match")
+
     return Match(
         MatchNumber(num),
         f"Match {num}",

--- a/tests/test_base_knockout_scheduler.py
+++ b/tests/test_base_knockout_scheduler.py
@@ -64,6 +64,7 @@ def get_scheduler(
     }
     config: BaseKnockoutScheduleData = {
         'match_periods': {'knockout': [period_config]},
+        'brackets': (),
     }
     arenas = [ArenaName('A')]
 

--- a/tests/test_knockout_scheduler.py
+++ b/tests/test_knockout_scheduler.py
@@ -83,6 +83,7 @@ def get_scheduler(
     }
     config: AutoKnockoutScheduleData = {
         'match_periods': {'knockout': [period_config]},
+        'brackets': (),
         'knockout': knockout_config,
     }
     arenas = [ArenaName('A')]

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -10,6 +10,9 @@ from unittest import mock
 from league_ranker import RankedPosition
 
 from sr.comp.knockout_scheduler import StaticScheduler, UNKNOWABLE_TEAM
+from sr.comp.knockout_scheduler.base_scheduler import (
+    DEFAULT_KNOCKOUT_BRACKET_NAME,
+)
 from sr.comp.knockout_scheduler.static_scheduler import (
     InvalidReferenceError,
     InvalidSeedError,
@@ -232,7 +235,7 @@ def build_5_matches(places, *, first_match_number=0):
             end,
             MatchType.knockout,
             use_resolved_ranking=True,
-            knockout_bracket='default',
+            knockout_bracket=DEFAULT_KNOCKOUT_BRACKET_NAME,
         )
         for (idx, name), (start, end), teams in zip(
             enumerate(names, start=first_match_number),

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -191,6 +191,7 @@ def get_scheduler(
     }
     config: StaticKnockoutScheduleData = {
         'match_periods': {'knockout': [period_config]},
+        'brackets': (),
         'static_knockout': matches_config,
     }
     arenas = [ArenaName('A')]

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import unittest
 from collections import OrderedDict
 from collections.abc import Collection, Mapping
@@ -16,7 +17,13 @@ from sr.comp.knockout_scheduler.static_scheduler import (
     StaticKnockoutScheduleData,
     WrongNumberOfTeamsError,
 )
-from sr.comp.match_period import Delay, Match, MatchSlot, MatchType
+from sr.comp.match_period import (
+    Delay,
+    KnockoutMatch,
+    Match,
+    MatchSlot,
+    MatchType,
+)
 from sr.comp.scores import LeaguePosition, LeaguePositions
 from sr.comp.teams import Team
 from sr.comp.types import (
@@ -216,7 +223,17 @@ def build_5_matches(places, *, first_match_number=0):
     ]
 
     matches = [
-        Match(idx, name.format(idx), 'A', teams, start, end, MatchType.knockout, True)
+        KnockoutMatch(
+            idx,
+            name.format(idx),
+            'A',
+            teams,
+            start,
+            end,
+            MatchType.knockout,
+            use_resolved_ranking=True,
+            knockout_bracket='default',
+        )
         for (idx, name), (start, end), teams in zip(
             enumerate(names, start=first_match_number),
             times,
@@ -225,7 +242,7 @@ def build_5_matches(places, *, first_match_number=0):
     ]
 
     # Final has different resolution expectations
-    matches[-1] = matches[-1]._replace(use_resolved_ranking=False)
+    matches[-1] = dataclasses.replace(matches[-1], use_resolved_ranking=False)
 
     return [{'A': match} for match in matches]
 


### PR DESCRIPTION
Knockout brackets are (at this point) a purely display related concern to enable splitting the diagram shown on the screens into more manageable chunks. The expectation is that they will be used for e.g: a double elimination style knockout where there's an "Upper" and "Lower" bracket, but the mapping from match to bracket is arbitrary.

This PR supports loading knockout brackets in the static knockout scheduler and exposing them in the Python API.

Related:
- https://github.com/PeterJCLaw/srcomp-http/pull/23
- https://github.com/srobo/srcomp-screens/pull/17