### PR TITLE
Validate configured knockout brackets are consistent

### DIFF
--- a/sr/comp/knockout_scheduler/base_scheduler.py
+++ b/sr/comp/knockout_scheduler/base_scheduler.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
-from typing import Generic, TypedDict, TypeVar
+import collections
+import difflib
+from collections.abc import Collection, Iterable, Mapping, Sequence
+from typing import final, Generic, TypedDict, TypeVar
 
-from ..match_period import Match, MatchPeriod, MatchType
+from .. import text_utils
+from ..match_period import KnockoutMatch, Match, MatchPeriod, MatchType
 from ..scores import Scores
 from ..teams import Team
 from ..types import ArenaName, KnockoutBracketData, MatchId, MatchNumber, TLA
@@ -28,6 +31,40 @@ class BaseKnockoutScheduleData(TypedDict):
 TConfig = TypeVar('TConfig', bound=BaseKnockoutScheduleData)
 
 DEFAULT_KNOCKOUT_BRACKET_NAME = 'default'
+
+
+class InvalidKnockoutBracketsError(Exception):
+    def __init__(
+        self,
+        missing_brackets: Mapping[str, Collection[KnockoutMatch]],
+        extra_brackets: Collection[str],
+        known_brackets: Collection[str],
+    ) -> None:
+        super().__init__(missing_brackets, extra_brackets, known_brackets)
+        self.missing_brackets = missing_brackets
+        self.extra_brackets = extra_brackets
+        self.known_brackets = known_brackets
+
+    def __str__(self) -> str:
+        messages = ["Invalid knockout brackets configuration."]
+
+        if self.missing_brackets:
+            missing_str = ", ".join(
+                f"{bracket!r} (in {text_utils.join_and(x.display_name for x in matches)}; "
+                f"close matches: {difflib.get_close_matches(bracket, self.known_brackets)})"
+                for bracket, matches in self.missing_brackets.items()
+            )
+            messages.append(
+                f"The following brackets are referenced but not defined: {missing_str}.",
+            )
+
+        if self.extra_brackets:
+            extra_str = text_utils.join_and(repr(x) for x in self.extra_brackets)
+            messages.append(
+                f"The following brackets are defined but not used: {extra_str}.",
+            )
+
+        return " ".join(messages)
 
 
 class BaseKnockoutScheduler(Generic[TConfig]):
@@ -235,6 +272,29 @@ class BaseKnockoutScheduler(Generic[TConfig]):
         self.knockout_rounds.append(knockout_round)
 
         return knockout_round
+
+    @final
+    def validate_brackets(self) -> None:
+        valid_bracket_ids = set(x.name for x in self.knockout_brackets)
+
+        matches_by_bracket: collections.defaultdict[str, list[KnockoutMatch]]
+        matches_by_bracket = collections.defaultdict(list)
+        for knockout_round in self.knockout_rounds:
+            for match in knockout_round:
+                matches_by_bracket[match.knockout_bracket].append(match)
+
+        missing_brackets = {
+            x: y
+            for x, y in matches_by_bracket.items()
+            if x not in valid_bracket_ids
+        }
+        extra_brackets = valid_bracket_ids - matches_by_bracket.keys()
+        if missing_brackets or extra_brackets:
+            raise InvalidKnockoutBracketsError(
+                missing_brackets,
+                extra_brackets,
+                valid_bracket_ids,
+            )
 
     def add_knockouts(self) -> None:
         """

--- a/sr/comp/knockout_scheduler/types.py
+++ b/sr/comp/knockout_scheduler/types.py
@@ -5,7 +5,7 @@ import datetime
 from collections.abc import Collection, Iterable
 from typing import Protocol, TypedDict
 
-from sr.comp.match_period import Delay, Match, MatchSlot
+from sr.comp.match_period import Delay, KnockoutMatch, MatchSlot
 from sr.comp.types import MatchPeriodData
 
 
@@ -37,7 +37,7 @@ class KnockoutPeriodData(TypedDict):
     knockout: list[MatchPeriodData]
 
 
-class KnockoutRound(list[Match]):
+class KnockoutRound(list[KnockoutMatch]):
     """
     A round of matches within the knockout stages.
 
@@ -46,6 +46,6 @@ class KnockoutRound(list[Match]):
     part of the public interface. Consumers should treat this as a ``Sequence``.
     """
 
-    def __init__(self, name: str, matches: Iterable[Match] = ()):
+    def __init__(self, name: str, matches: Iterable[KnockoutMatch] = ()):
         super().__init__(matches)
         self.name = name

--- a/sr/comp/matches.py
+++ b/sr/comp/matches.py
@@ -170,6 +170,7 @@ class MatchSchedule:
             )
 
         k.add_knockouts()
+        k.validate_brackets()
 
         schedule.knockout_brackets = k.knockout_brackets
         schedule.knockout_rounds = k.knockout_rounds

--- a/sr/comp/text_utils.py
+++ b/sr/comp/text_utils.py
@@ -1,0 +1,21 @@
+from collections.abc import Iterable
+
+
+def join_and(items: Iterable[object]) -> str:
+    """
+    Produce a mostly comma-separated list, with the last conjunction being "and"
+    rather than a comma.
+
+    >>> join_and(["spam", "eggs", "ham"])
+    "spam, eggs and ham"
+    """
+    strings = [str(x) for x in items]
+    if not strings:
+        return ""
+
+    if len(strings) == 1:
+        return strings[0]
+
+    *rest, last = strings
+
+    return " and ".join((", ".join(rest), last))

--- a/sr/comp/validation.py
+++ b/sr/comp/validation.py
@@ -16,6 +16,7 @@ from .knockout_scheduler import UNKNOWABLE_TEAM
 from .match_period import Match, MatchSlot, MatchType
 from .matches import MatchSchedule
 from .scores import BaseScores
+from .text_utils import join_and
 from .types import ArenaName, MatchId, MatchNumber, TLA
 
 ErrorType = NewType('ErrorType', str)
@@ -54,19 +55,6 @@ def with_source(
 ) -> Iterator[ValidationError]:
     for error in naive_errors:
         yield error.with_source(*source)
-
-
-def join_and(items: Iterable[object]) -> str:
-    strings = [str(x) for x in items]
-    if not strings:
-        return ""
-
-    if len(strings) == 1:
-        return strings[0]
-
-    *rest, last = strings
-
-    return " and ".join((", ".join(rest), last))
 
 
 def report_errors(error_type: ErrorType, id_: object, errors: list[str]) -> None:

--- a/tests/test_base_knockout_scheduler.py
+++ b/tests/test_base_knockout_scheduler.py
@@ -12,9 +12,12 @@ from league_ranker import RankedPosition
 from sr.comp.knockout_scheduler.base_scheduler import (
     BaseKnockoutScheduleData,
     BaseKnockoutScheduler,
+    DEFAULT_KNOCKOUT_BRACKET_NAME,
+    InvalidKnockoutBracketsError,
     UNKNOWABLE_TEAM,
 )
-from sr.comp.match_period import Delay, MatchSlot
+from sr.comp.knockout_scheduler.types import KnockoutRound
+from sr.comp.match_period import Delay, MatchSlot, MatchType
 from sr.comp.scores import LeaguePosition, LeaguePositions
 from sr.comp.teams import Team
 from sr.comp.types import ArenaName, GamePoints, MatchId, MatchPeriodData, TLA
@@ -185,4 +188,80 @@ class BaseKnockoutSchedulerTests(unittest.TestCase):
         self.assertEqual(
             ['ABC', 'DEF'],
             scheduler._get_seeds(),
+        )
+
+    def test_validate_brackets_ok(self) -> None:
+        scheduler = get_scheduler()
+        scheduler.knockout_rounds = [
+            KnockoutRound(
+                "Knockouts",
+                [
+                    build_match(type_=MatchType.knockout),  # type: ignore[list-item]
+                ],
+            ),
+        ]
+        scheduler.validate_brackets()
+
+    def test_validate_brackets_extra(self) -> None:
+        scheduler = get_scheduler()
+        scheduler.knockout_rounds = []
+
+        with self.assertRaises(InvalidKnockoutBracketsError) as cm:
+            scheduler.validate_brackets()
+
+        self.assertEqual(
+            (
+                {},
+                set([DEFAULT_KNOCKOUT_BRACKET_NAME]),
+                set([DEFAULT_KNOCKOUT_BRACKET_NAME]),
+            ),
+            (
+                cm.exception.missing_brackets,
+                cm.exception.extra_brackets,
+                cm.exception.known_brackets,
+            ),
+            "Wrong error data",
+        )
+
+        self.assertIn(
+            "Invalid",
+            str(cm.exception),
+            "Bad error message",
+        )
+
+    def test_validate_brackets_mismatch(self) -> None:
+        match = build_match(
+            type_=MatchType.knockout,
+            knockout_bracket='mismatch',
+        )
+
+        scheduler = get_scheduler()
+        scheduler.knockout_rounds = [
+            KnockoutRound(
+                "Knockouts",
+                [match],  # type: ignore[list-item]
+            ),
+        ]
+
+        with self.assertRaises(InvalidKnockoutBracketsError) as cm:
+            scheduler.validate_brackets()
+
+        self.assertEqual(
+            (
+                {'mismatch': [match]},
+                set([DEFAULT_KNOCKOUT_BRACKET_NAME]),
+                set([DEFAULT_KNOCKOUT_BRACKET_NAME]),
+            ),
+            (
+                cm.exception.missing_brackets,
+                cm.exception.extra_brackets,
+                cm.exception.known_brackets,
+            ),
+            "Wrong error data",
+        )
+
+        self.assertIn(
+            "Invalid",
+            str(cm.exception),
+            "Bad error message",
         )


### PR DESCRIPTION
This aims to avoid cases where the configuration is internally inconsistent, reducing the changes for errors.