### PR TITLE
Flexible knockout spacing

### DIFF
--- a/sr/comp/knockout_scheduler/automatic_scheduler.py
+++ b/sr/comp/knockout_scheduler/automatic_scheduler.py
@@ -7,7 +7,7 @@ import math
 from collections.abc import Iterable, Mapping, Sized
 
 from ..match_period import KnockoutMatch, Match, MatchSlot, MatchType
-from ..match_period_clock import MatchPeriodClock, OutOfTimeException
+from ..match_period_clock import MatchPeriodClock, OutOfTimeException, Spacing
 from ..scores import Scores
 from ..teams import Team
 from ..types import ArenaName, MatchNumber, ScheduleKnockoutData, TLA
@@ -181,16 +181,26 @@ class KnockoutScheduler(BaseKnockoutScheduler[AutoKnockoutScheduleData]):
     def get_rounds_remaining(prev_matches: Sized) -> int:
         return int(math.log(len(prev_matches), 2))
 
+    @staticmethod
+    def parse_spacing(seconds: int) -> Spacing:
+        return Spacing.fixed(datetime.timedelta(seconds=seconds))
+
+    def _apply_spacing(self, spacing: Spacing) -> None:
+        self.clock.apply_spacing(
+            spacing=spacing,
+            recover_time=self.schedule._recover_time,
+        )
+
     def _add_knockouts(self) -> None:
         knockout_conf = self.config['knockout']
-        round_spacing = datetime.timedelta(seconds=knockout_conf['round_spacing'])
+        round_spacing = self.parse_spacing(knockout_conf['round_spacing'])
 
         self._add_first_round(conf_arity=knockout_conf.get('arity'))
 
         while len(self.knockout_rounds[-1]) > 1:
 
             # Add the delay between rounds
-            self.clock.advance_time(round_spacing)
+            self._apply_spacing(spacing=round_spacing)
 
             # Number of rounds remaining to be added
             rounds_remaining = self.get_rounds_remaining(self.knockout_rounds[-1])
@@ -203,8 +213,8 @@ class KnockoutScheduler(BaseKnockoutScheduler[AutoKnockoutScheduleData]):
 
             if len(self.knockout_rounds[-1]) == 2:
                 # Extra delay before the final match
-                final_delay = datetime.timedelta(seconds=knockout_conf['final_delay'])
-                self.clock.advance_time(final_delay)
+                final_delay = self.parse_spacing(knockout_conf['final_delay'])
+                self._apply_spacing(spacing=final_delay)
 
             self._add_round(arenas, rounds_remaining - 1)
 

--- a/sr/comp/knockout_scheduler/types.py
+++ b/sr/comp/knockout_scheduler/types.py
@@ -14,6 +14,9 @@ class ScheduleHost(Protocol):
     def delays(self) -> Collection[Delay]:
         ...
 
+    def _recover_time(self, recovered_time: Delay) -> None:
+        ...
+
     @property
     def matches(self) -> list[MatchSlot]:
         ...

--- a/sr/comp/match_period_clock.py
+++ b/sr/comp/match_period_clock.py
@@ -2,10 +2,46 @@
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
+from typing_extensions import Self
 
 from .match_period import Delay, MatchPeriod
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Spacing:
+    """
+    Spacing which can be applied to a ``MatchPeriodClock``.
+
+    nominal == delay_flex + minimum.
+    """
+
+    delay_flex: datetime.timedelta
+    """The maximum amount of delay time to absorb."""
+
+    minimum: datetime.timedelta
+    """The minimum amount of time to advance."""
+
+    nominal: datetime.timedelta
+    """The initial amount of time to advance, assuming there are no delays."""
+
+    @classmethod
+    def fixed(cls, nominal: datetime.timedelta) -> Self:
+        return cls(
+            delay_flex=datetime.timedelta(0),
+            minimum=nominal,
+            nominal=nominal,
+        )
+
+    def __post_init__(self) -> None:
+        zero = datetime.timedelta(0)
+        if self.delay_flex < zero or self.minimum < zero or self.nominal < zero:
+            raise ValueError("Spacing values cannot be negative.")
+
+        if self.delay_flex + self.minimum != self.nominal:
+            raise ValueError("Spacing durations are inconsistent.")
 
 
 class OutOfTimeException(Exception):
@@ -118,6 +154,30 @@ class MatchPeriodClock:
 
         self._current_time += duration
         self._apply_delays()
+
+    def apply_spacing(self, spacing: Spacing, recover_time: Callable[[Delay], None]) -> None:
+        """
+        Apply a given spacing to make some time pass. This is expected to be
+        called when inserting a variable length gap between matches.
+
+        The ``recover_time`` parameter should be a callable which updates the
+        central view of delays in the system and will be called with a negative
+        delay when time is recovered.
+        """
+
+        if self._total_delay is not None:
+            delay_to_absorb = min(self._total_delay, spacing.delay_flex)
+
+            if delay_to_absorb:
+                recovered_time = Delay(
+                    # A negative delay recovers time.
+                    delay=-delay_to_absorb,
+                    time=self._current_time,
+                )
+                self._delays.insert(0, recovered_time)
+                recover_time(recovered_time)
+
+        self.advance_time(spacing.nominal)
 
     def _apply_delays(self) -> None:
         delays = self._delays

--- a/sr/comp/match_period_clock.py
+++ b/sr/comp/match_period_clock.py
@@ -41,7 +41,10 @@ class Spacing:
             raise ValueError("Spacing values cannot be negative.")
 
         if self.delay_flex + self.minimum != self.nominal:
-            raise ValueError("Spacing durations are inconsistent.")
+            raise ValueError(
+                "Spacing durations are inconsistent. "
+                f"({self.delay_flex} + {self.minimum} != {self.nominal})",
+            )
 
 
 class OutOfTimeException(Exception):

--- a/sr/comp/matches.py
+++ b/sr/comp/matches.py
@@ -338,6 +338,29 @@ class MatchSchedule:
         self.delays = delays
 
     def _recover_time(self, recovered_time: Delay) -> None:
+        """
+        Callback to record that previously delayed time has been recovered.
+
+        This is expected to be passed to `MatchPeriodClock.apply_spacing` as
+        part of either the knockouts or league scheduling. There it is called as
+        to indicate that a flexible gap in the schedule has been shrunk,
+        recovering time previously lost to delays.
+
+        This is necessary to ensure that the central list of delays (held on
+        this instance) is in sync with the actual timings, so that calls to
+        `delay_at` return values which correspond correctly.
+
+        The passed delay value should:
+         - be at the `time` of the earlier end of the time window which was
+           shortened
+         - have a *negative* `delay` value, with magnitude of the amount of time
+           recovered
+        """
+        if recovered_time.delay >= datetime.timedelta(0):
+            raise ValueError(
+                f"Recovered duration should be negative. (Got {recovered_time!r})",
+            )
+
         bisect.insort(self.delays, recovered_time, key=lambda x: x.time)
 
     def remove_drop_outs(

--- a/sr/comp/matches.py
+++ b/sr/comp/matches.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import bisect
 import datetime
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
@@ -335,6 +336,9 @@ class MatchSchedule:
 
         delays.sort(key=lambda x: x.time)
         self.delays = delays
+
+    def _recover_time(self, recovered_time: Delay) -> None:
+        bisect.insort(self.delays, recovered_time, key=lambda x: x.time)
 
     def remove_drop_outs(
         self,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import bisect
 import datetime
 import random
-from collections.abc import Collection, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from typing import TypeVar
 
 from sr.comp.knockout_scheduler.base_scheduler import (
@@ -127,11 +128,15 @@ class FakeSchedule:
     def __init__(
         self,
         *,
-        delays: Collection[Delay],
+        delays: list[Delay],
         matches: list[MatchSlot],
         match_duration: datetime.timedelta,
     ):
         self.delays = delays
+        self.delays.sort(key=lambda x: x.time)
         self.matches = matches
         self.match_duration = match_duration
         self.n_league_matches = len(matches)
+
+    def _recover_time(self, recovered_time: Delay) -> None:
+        bisect.insort(self.delays, recovered_time, key=lambda x: x.time)

--- a/tests/test_base_knockout_scheduler.py
+++ b/tests/test_base_knockout_scheduler.py
@@ -4,7 +4,7 @@ import datetime
 import random
 import unittest
 from collections import OrderedDict
-from collections.abc import Collection, Mapping
+from collections.abc import Mapping
 from unittest import mock
 
 from league_ranker import RankedPosition
@@ -30,7 +30,7 @@ def get_scheduler(
     positions: LeaguePositions | None = None,
     knockout_positions: Mapping[MatchId, Mapping[TLA, RankedPosition]] | None = None,
     league_game_points: dict[MatchId, Mapping[TLA, GamePoints]] | None = None,
-    delays: Collection[Delay] | None = None,
+    delays: list[Delay] | None = None,
     teams: dict[TLA, Team] | None = None,
     num_teams_per_arena: int = 4,
 ) -> BaseKnockoutScheduler[BaseKnockoutScheduleData]:

--- a/tests/test_knockout_scheduler.py
+++ b/tests/test_knockout_scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 from collections import defaultdict, OrderedDict
-from collections.abc import Collection, Mapping
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -39,7 +39,7 @@ def get_scheduler(
     positions: LeaguePositions | None = None,
     knockout_positions: Mapping[MatchId, Mapping[TLA, RankedPosition]] | None = None,
     league_game_points: dict[MatchId, Mapping[TLA, GamePoints]] | None = None,
-    delays: Collection[Delay] | None = None,
+    delays: list[Delay] | None = None,
     teams: dict[TLA, Team] | None = None,
     num_teams_per_arena: int = 4,
 ) -> KnockoutScheduler:

--- a/tests/test_match_period_clock.py
+++ b/tests/test_match_period_clock.py
@@ -4,7 +4,11 @@ import datetime
 import unittest
 
 from sr.comp.match_period import MatchPeriod, MatchSlot, MatchType
-from sr.comp.match_period_clock import MatchPeriodClock, OutOfTimeException
+from sr.comp.match_period_clock import (
+    MatchPeriodClock,
+    OutOfTimeException,
+    Spacing,
+)
 from sr.comp.matches import Delay
 
 
@@ -234,6 +238,343 @@ class AdvanceTimeTests(MatchPeriodClockTestsBase):
             curr_time,
             "Time should advance by the given amount (2) plus the size of the "
             "intervening delays (1+1)",
+        )
+
+
+class ApplySpacingTests(MatchPeriodClockTestsBase):
+    REF = datetime.datetime(2000, 1, 1)
+
+    maxDiff = None
+
+    @classmethod
+    def build_delay(cls, *, time: int, delay: int) -> Delay:
+        return Delay(
+            time=cls.REF.replace(second=time),
+            delay=datetime.timedelta(seconds=delay),
+        )
+
+    def build_match_period(  # type: ignore[override]
+        self,
+        start: int,
+        end: int,
+    ) -> MatchPeriod:
+        return super().build_match_period(
+            start=self.REF.replace(second=start),
+            end=self.REF.replace(second=end),
+        )
+
+    def assertApplySpacing(
+        self,
+        clock: MatchPeriodClock,
+        nominal: int,
+        flex: int = 0,
+        expected_recovery: int | None = None,
+    ) -> None:
+        recovered = None
+
+        def recovery(delay: Delay) -> None:
+            nonlocal recovered
+            self.assertIsNone(recovered, "Should only recover time once")
+            recovered = -delay.delay.total_seconds()
+
+        clock.apply_spacing(
+            Spacing(
+                delay_flex=datetime.timedelta(seconds=flex),
+                minimum=datetime.timedelta(seconds=nominal - flex),
+                nominal=datetime.timedelta(seconds=nominal),
+            ),
+            recover_time=recovery,
+        )
+
+        self.assertEqual(expected_recovery, recovered, "Wrong amount of recovered time")
+
+    def assertCurrentTime(self, clock: MatchPeriodClock, seconds: int, message: str) -> None:
+        self.assertEqual(
+            seconds,
+            clock.current_time.second,
+            message,
+        )
+
+    # No flex -- should behave just like `advance_time`
+
+    def test_no_delays(self) -> None:
+        period = self.build_match_period(0, 10)
+        clock = MatchPeriodClock(period, [])
+        self.assertCurrentTime(clock, 0, "Should start at the start of the period")
+
+        self.assertApplySpacing(clock, 1)
+
+        self.assertCurrentTime(clock, 1, "Time should advance by the given amount (1)")
+
+        self.assertApplySpacing(clock, 2)
+
+        self.assertCurrentTime(clock, 3, "Time should advance by the given amount (2)")
+
+    def test_with_delays(self) -> None:
+        period = self.build_match_period(0, 50)
+        delays = [
+            self.build_delay(time=1, delay=1),
+            self.build_delay(time=5, delay=2),
+        ]
+        clock = MatchPeriodClock(period, delays)
+        self.assertCurrentTime(clock, 0, "Should start at the start of the period")
+
+        self.assertApplySpacing(clock, 1)  # plus a delay of 1 at time=1
+
+        self.assertCurrentTime(
+            clock,
+            2,
+            "Time should advance by the given amount (1) plus the size of the "
+            "delay it meets",
+        )
+
+        self.assertApplySpacing(clock, 2)
+
+        self.assertCurrentTime(
+            clock,
+            4,
+            "Time should advance by the given amount (2) only; there are no "
+            "intervening delays",
+        )
+
+        self.assertApplySpacing(clock, 2)  # takes us to 6, plus a delay of 2 at time=5
+
+        self.assertCurrentTime(
+            clock,
+            8,
+            "Time should advance by the given amount (2) plus the size of the "
+            "intervening delay (2)",
+        )
+
+        self.assertApplySpacing(clock, 2)
+
+        self.assertCurrentTime(
+            clock,
+            10,
+            "Time should advance by the given amount (2) only; there are no "
+            "intervening delays",
+        )
+
+    def test_overlapping_delays(self) -> None:
+        period = self.build_match_period(0, 10)
+        delays = [
+            self.build_delay(time=1, delay=2),  # from 1 -> 3
+            self.build_delay(time=2, delay=1),  # extra at 2, so 1 -> 4
+        ]
+        clock = MatchPeriodClock(period, delays)
+        self.assertCurrentTime(clock, 0, "Should start at the start of the period")
+
+        self.assertApplySpacing(clock, 2)  # plus a total delay of 3
+
+        self.assertCurrentTime(
+            clock,
+            5,
+            "Time should advance by the given amount (2) plus the size of the "
+            "intervening delays (1+2)",
+        )
+
+    def test_touching_delays(self) -> None:
+        period = self.build_match_period(0, 10)
+        delays = [
+            self.build_delay(time=1, delay=1),  # from 1 -> 2
+            self.build_delay(time=2, delay=1),  # from 2 -> 3
+        ]
+        clock = MatchPeriodClock(period, delays)
+        self.assertCurrentTime(clock, 0, "Should start at the start of the period")
+
+        self.assertApplySpacing(clock, 2)  # plus a total delay of 2
+
+        self.assertCurrentTime(
+            clock,
+            4,
+            "Time should advance by the given amount (2) plus the size of the "
+            "intervening delays (1+1)",
+        )
+
+    # Flex greater than the delays -- should fully absorb the delays
+
+    def test_flex_no_delays(self) -> None:
+        period = self.build_match_period(0, 10)
+        clock = MatchPeriodClock(period, [])
+        self.assertCurrentTime(clock, 0, "Should start at the start of the period")
+
+        self.assertApplySpacing(clock, 2, flex=1)
+
+        self.assertCurrentTime(clock, 2, "Time should advance by the given amount (2)")
+
+        self.assertApplySpacing(clock, 2, flex=1)
+
+        self.assertCurrentTime(clock, 4, "Time should advance by the given amount (2)")
+
+    def test_flex_ignores_future_delays(self) -> None:
+        period = self.build_match_period(0, 50)
+        delays = [
+            self.build_delay(time=1, delay=1),  # at 1 -> 2
+            self.build_delay(time=3, delay=2),  # at 3 -> 5
+        ]
+        clock = MatchPeriodClock(period, delays)
+        self.assertCurrentTime(clock, 0, "Should start at the start of the period")
+
+        # Flex ignore delays which happen after the start of the spacing we're adding.
+        self.assertApplySpacing(clock, 3, flex=2)
+
+        self.assertCurrentTime(
+            clock,
+            6,
+            "Time should advance by the given amount (3) plus the size of the "
+            "(future) delays it meets",
+        )
+
+    def test_flex_gt_delays_with_delays(self) -> None:
+        period = self.build_match_period(0, 50)
+        delays = [
+            self.build_delay(time=0, delay=1),  # seen, absorbed
+            self.build_delay(time=1, delay=1),   # seen, absorbed
+            self.build_delay(time=9, delay=2),   # future, ignored initially
+        ]
+        clock = MatchPeriodClock(period, delays)
+        clock.advance_time(datetime.timedelta(seconds=3))   # plus delays (2)
+        self.assertCurrentTime(clock, 5, "Should be after the initial delays")
+
+        # Absorbs both delays which were already "expended", but not the one
+        # which is in the future.
+        self.assertApplySpacing(clock, 5, flex=3, expected_recovery=2)
+
+        self.assertCurrentTime(
+            clock,
+            8,
+            "Time should advance by the given amount (5) minus the historic delays (2)",
+        )
+
+        # Doesn't absorb any of the delay which happens "during" this spacing
+        self.assertApplySpacing(clock, 2, flex=1, expected_recovery=None)
+
+        self.assertCurrentTime(
+            clock,
+            12,
+            "Time should advance by the given amount (2) plus the size of the "
+            "delay it meets (2)",
+        )
+
+        # Recovers from the previous delay (2), with some space left over
+        self.assertApplySpacing(clock, 4, flex=3, expected_recovery=2)
+
+        self.assertCurrentTime(
+            clock,
+            14,
+            "Time should advance by the given amount (4) minus the historic delays (2)",
+        )
+
+        # no flex needed, we're on track
+        self.assertApplySpacing(clock, 2, flex=1, expected_recovery=None)
+
+        self.assertCurrentTime(
+            clock,
+            16,
+            "Time should advance by the given amount (2) only; there are no "
+            "remaining delays",
+        )
+
+    def test_flex_delays_overlapping_delays(self) -> None:
+        period = self.build_match_period(0, 10)
+        delays = [
+            self.build_delay(time=1, delay=2),  # from 1 -> 3
+            self.build_delay(time=2, delay=1),  # extra at 2, so 1 -> 4
+        ]
+        clock = MatchPeriodClock(period, delays)
+        self.assertCurrentTime(clock, 0, "Should start at the start of the period")
+
+        # No flexing, delays are after the spacing starts
+        self.assertApplySpacing(clock, 4, flex=3, expected_recovery=None)
+
+        self.assertCurrentTime(
+            clock,
+            7,
+            "Time should advance by the given amount (4) absorbing the "
+            "intervening delays (1+2)",
+        )
+
+    def test_flex_delays_touching_delays(self) -> None:
+        period = self.build_match_period(0, 10)
+        delays = [
+            self.build_delay(time=1, delay=1),  # from 1 -> 2
+            self.build_delay(time=2, delay=1),  # from 2 -> 3
+        ]
+        clock = MatchPeriodClock(period, delays)
+        self.assertCurrentTime(clock, 0, "Should start at the start of the period")
+
+        # No flexing, delays are after the spacing starts
+        self.assertApplySpacing(clock, 4, flex=3, expected_recovery=None)
+
+        self.assertCurrentTime(
+            clock,
+            6,
+            "Time should advance by the given amount (3) plus the size of the "
+            "(future) delays it meets",
+        )
+
+    # Flex less than the delays -- should partially absorb the delays
+
+    def test_flex_lt_delays_with_delays(self) -> None:
+        period = self.build_match_period(0, 50)
+        delays = [
+            self.build_delay(time=0, delay=2),  # seen, absorbed
+            self.build_delay(time=1, delay=2),  # seen, absorbed
+            self.build_delay(time=9, delay=2),  # future, ignored initially
+        ]
+        clock = MatchPeriodClock(period, delays)
+        clock.advance_time(datetime.timedelta(seconds=1))   # plus delays (4)
+        self.assertCurrentTime(clock, 5, "Should be after the initial delays")
+
+        # Absorbs some of the delays which were already "expended", but not the
+        # one which is in the future.
+        self.assertApplySpacing(clock, 4, flex=1, expected_recovery=1)
+
+        self.assertCurrentTime(
+            clock,
+            8,
+            "Time should advance by the given amount (4) minus a portion of the "
+            "historic delays (1)",
+        )
+
+        # Doesn't absorb any of the delay which happens "during" this spacing,
+        # but should absorb some of the previous delay
+        self.assertApplySpacing(clock, 3, flex=1, expected_recovery=1)
+
+        self.assertCurrentTime(
+            clock,
+            12,
+            "Time should advance by the given amount (3) minus a portion of the "
+            "historic delays (1) plus the size of the delay it meets (2)",
+        )
+
+        # Absorbs a portion of the historic delays
+        self.assertApplySpacing(clock, 2, flex=1, expected_recovery=1)
+
+        self.assertCurrentTime(
+            clock,
+            13,
+            "Time should advance by the given amount (3) minus a portion of the "
+            "historic delays (1)",
+        )
+
+        # Recovers from the previous delays (1+2), with some space left over
+        self.assertApplySpacing(clock, 5, flex=4, expected_recovery=3)
+
+        self.assertCurrentTime(
+            clock,
+            15,
+            "Time should advance by the given amount (5) minus the historic delays (3)",
+        )
+
+        # no flex needed, we're on track
+        self.assertApplySpacing(clock, 2, flex=1, expected_recovery=None)
+
+        self.assertCurrentTime(
+            clock,
+            17,
+            "Time should advance by the given amount (2) only; there are no "
+            "remaining delays",
         )
 
 

--- a/tests/test_matches.py
+++ b/tests/test_matches.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
-from sr.comp.match_period import Match
+from sr.comp.match_period import Delay, Match
 from sr.comp.matches import MatchSchedule, parse_ranges
 from sr.comp.teams import Team
 from sr.comp.types import MatchNumber, TLA
@@ -427,6 +427,19 @@ class MatchesTests(unittest.TestCase):
         delay = match_sched.delay_at(when)
 
         self.assertEqual(timedelta(seconds=15), delay)
+
+    def test_delay_after_recovered_time(self) -> None:
+        match_sched = load_basic_data()
+
+        match_sched._recover_time(Delay(
+            time=match_sched.delays[0].time,
+            delay=timedelta(seconds=-10),
+        ))
+
+        when = datetime(2014, 3, 26, 13, 2)
+        delay = match_sched.delay_at(when)
+
+        self.assertEqual(timedelta(seconds=5), delay)
 
     def test_basic_delay(self):
         matches = load_basic_data()

--- a/tests/test_static_knockout_scheduler.py
+++ b/tests/test_static_knockout_scheduler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import unittest
 from collections import OrderedDict
-from collections.abc import Collection, Mapping
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -145,7 +145,7 @@ def get_scheduler(
     positions: LeaguePositions | None = None,
     knockout_positions: Mapping[MatchId, Mapping[TLA, RankedPosition]] | None = None,
     league_game_points: dict[MatchId, Mapping[TLA, GamePoints]] | None = None,
-    delays: Collection[Delay] | None = None,
+    delays: list[Delay] | None = None,
     teams: dict[TLA, Team] | None = None,
 ) -> StaticScheduler:
     matches = matches or []


### PR DESCRIPTION
This introduces an internal mechanism to enable having flexible length gaps within `MatchPeriod`s. The intent is that this will be used to enable the knockout schedulers to better control their timings, potentially allowing for automatically recovering time after a delay.

This PR connects up the machinery to the automatic knockout scheduler, but doesn't add a way to configure it -- that will come separately.

Suggest review by commit.
It may also be worth looking at https://github.com/PeterJCLaw/srcomp/pull/59/changes/524a0d5b3b8ab0d0af24d239ae984da4207cab8a to get a feel for how this is expected to be used.