### PR TITLE
Add support for specifying knockouts structure separate from their timings

### DIFF
--- a/sr/comp/comp.py
+++ b/sr/comp/comp.py
@@ -121,6 +121,7 @@ class SRComp:
         self.schedule = matches.MatchSchedule.create(
             self.root / 'schedule.yaml',
             self.root / 'league.yaml',
+            self.root / 'knockout.yaml',
             self.scores,
             self.arenas,
             self.num_teams_per_arena,

--- a/sr/comp/knockout_scheduler/__init__.py
+++ b/sr/comp/knockout_scheduler/__init__.py
@@ -2,6 +2,10 @@
 
 from .automatic_scheduler import AutoKnockoutScheduleData, KnockoutScheduler
 from .base_scheduler import UNKNOWABLE_TEAM
+from .converters import (
+    modernise_automatic_knockout_config,
+    modernise_knockout_config_if_needed,
+)
 from .static_scheduler import StaticKnockoutScheduleData, StaticScheduler
 from .types import KnockoutBracket, KnockoutRound
 
@@ -10,6 +14,8 @@ __all__ = (
     'KnockoutBracket',
     'KnockoutRound',
     'KnockoutScheduler',
+    'modernise_automatic_knockout_config',
+    'modernise_knockout_config_if_needed',
     'StaticKnockoutScheduleData',
     'StaticScheduler',
     'UNKNOWABLE_TEAM',

--- a/sr/comp/knockout_scheduler/__init__.py
+++ b/sr/comp/knockout_scheduler/__init__.py
@@ -7,6 +7,10 @@ from .converters import (
     modernise_knockout_config_if_needed,
 )
 from .static_scheduler import StaticKnockoutScheduleData, StaticScheduler
+from .structured_scheduler import (
+    StructuredKnockoutScheduleData,
+    StructuredScheduler,
+)
 from .types import KnockoutBracket, KnockoutRound
 
 __all__ = (
@@ -18,5 +22,7 @@ __all__ = (
     'modernise_knockout_config_if_needed',
     'StaticKnockoutScheduleData',
     'StaticScheduler',
+    'StructuredKnockoutScheduleData',
+    'StructuredScheduler',
     'UNKNOWABLE_TEAM',
 )

--- a/sr/comp/knockout_scheduler/automatic_scheduler.py
+++ b/sr/comp/knockout_scheduler/automatic_scheduler.py
@@ -2,15 +2,24 @@
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import math
 from collections.abc import Iterable, Mapping, Sized
+from typing_extensions import Self
 
 from ..match_period import KnockoutMatch, Match, MatchSlot, MatchType
 from ..match_period_clock import MatchPeriodClock, OutOfTimeException, Spacing
 from ..scores import Scores
 from ..teams import Team
-from ..types import ArenaName, MatchNumber, ScheduleKnockoutData, TLA
+from ..types import (
+    ArenaName,
+    KnockoutRoundSpacingData,
+    MatchNumber,
+    ScheduleAutomaticKnockoutData,
+    ScheduleKnockoutRoundSpacingData,
+    TLA,
+)
 from . import seeding, stable_random
 from .base_scheduler import (
     BaseKnockoutScheduleData,
@@ -20,8 +29,50 @@ from .base_scheduler import (
 from .types import ScheduleHost
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class RoundsSpacing:
+    default: Spacing
+    overrides: Mapping[int, Spacing]
+
+    @classmethod
+    def parse(cls, spacing_data: ScheduleKnockoutRoundSpacingData) -> Self:
+        def build(spacing_entry: KnockoutRoundSpacingData) -> Spacing:
+            return Spacing(
+                delay_flex=datetime.timedelta(seconds=spacing_entry['delay_flex']),
+                minimum=datetime.timedelta(seconds=spacing_entry['minimum']),
+                nominal=datetime.timedelta(seconds=spacing_entry['nominal']),
+            )
+
+        default = build(spacing_data['default'])
+
+        overrides = {
+            num: build(entry)
+            for num, entry in spacing_data.get('overrides', {}).items()
+        }
+
+        return cls(default, overrides)
+
+    def __post_init__(self) -> None:
+        if not (
+            all(x < 0 for x in self.overrides.keys()) or
+            all(x > 0 for x in self.overrides.keys())
+        ):
+            raise ValueError(
+                "Invalid overrides configuration -- "
+                "all entries must be positive or all must be negative. "
+                f"Got {set(self.overrides.keys())}.",
+            )
+
+    def get(self, *, round_num: int, rounds_remaining: int) -> Spacing:
+        if (spacing := self.overrides.get(round_num)) is not None:
+            return spacing
+        if (spacing := self.overrides.get(-rounds_remaining)) is not None:
+            return spacing
+        return self.default
+
+
 class AutoKnockoutScheduleData(BaseKnockoutScheduleData):
-    knockout: ScheduleKnockoutData
+    knockout: ScheduleAutomaticKnockoutData
 
 
 class KnockoutScheduler(BaseKnockoutScheduler[AutoKnockoutScheduleData]):
@@ -181,10 +232,6 @@ class KnockoutScheduler(BaseKnockoutScheduler[AutoKnockoutScheduleData]):
     def get_rounds_remaining(prev_matches: Sized) -> int:
         return int(math.log(len(prev_matches), 2))
 
-    @staticmethod
-    def parse_spacing(seconds: int) -> Spacing:
-        return Spacing.fixed(datetime.timedelta(seconds=seconds))
-
     def _apply_spacing(self, spacing: Spacing) -> None:
         self.clock.apply_spacing(
             spacing=spacing,
@@ -193,28 +240,26 @@ class KnockoutScheduler(BaseKnockoutScheduler[AutoKnockoutScheduleData]):
 
     def _add_knockouts(self) -> None:
         knockout_conf = self.config['knockout']
-        round_spacing = self.parse_spacing(knockout_conf['round_spacing'])
+        rounds_spacing = RoundsSpacing.parse(knockout_conf['round_spacing'])
 
         self._add_first_round(conf_arity=knockout_conf.get('arity'))
 
         while len(self.knockout_rounds[-1]) > 1:
 
-            # Add the delay between rounds
-            self._apply_spacing(spacing=round_spacing)
-
             # Number of rounds remaining to be added
             rounds_remaining = self.get_rounds_remaining(self.knockout_rounds[-1])
+
+            # Add the delay between rounds
+            self._apply_spacing(rounds_spacing.get(
+                round_num=len(self.knockout_rounds),
+                rounds_remaining=rounds_remaining,
+            ))
 
             arenas: Iterable[ArenaName]
             if rounds_remaining <= knockout_conf['single_arena']['rounds']:
                 arenas = knockout_conf['single_arena']['arenas']
             else:
                 arenas = self.arenas
-
-            if len(self.knockout_rounds[-1]) == 2:
-                # Extra delay before the final match
-                final_delay = self.parse_spacing(knockout_conf['final_delay'])
-                self._apply_spacing(spacing=final_delay)
 
             self._add_round(arenas, rounds_remaining - 1)
 

--- a/sr/comp/knockout_scheduler/converters.py
+++ b/sr/comp/knockout_scheduler/converters.py
@@ -51,7 +51,10 @@ def modernise_knockout_config_if_needed(
         return cast(ScheduleKnockoutData, config)
 
     if config.get('static'):
-        return ScheduleStaticKnockoutData(scheduler='static')
+        static_config = ScheduleStaticKnockoutData(scheduler='static')
+        if (brackets := config.get('brackets')) is not None:
+            static_config['brackets'] = brackets
+        return static_config
 
     if 'single_arena' in config:
         return modernise_automatic_knockout_config(

--- a/sr/comp/knockout_scheduler/converters.py
+++ b/sr/comp/knockout_scheduler/converters.py
@@ -1,0 +1,61 @@
+"""Helpers to upgrade older configuration formats"""
+
+
+from __future__ import annotations
+
+from typing import cast
+
+from ..types import (
+    LegacyScheduleKnockoutData,
+    ScheduleAutomaticKnockoutData,
+    ScheduleKnockoutData,
+    ScheduleStaticKnockoutData,
+)
+
+
+def modernise_automatic_knockout_config(
+    old_config: LegacyScheduleKnockoutData,
+) -> ScheduleAutomaticKnockoutData:
+    round_spacing = old_config['round_spacing']
+    final_spacing = round_spacing + old_config['final_delay']
+
+    new_config = ScheduleAutomaticKnockoutData(
+        scheduler='automatic',
+        round_spacing={
+            'default': {
+                'delay_flex': 0,
+                'minimum': round_spacing,
+                'nominal': round_spacing,
+            },
+            'overrides': {
+                -1: {
+                    'delay_flex': 0,
+                    'minimum': final_spacing,
+                    'nominal': final_spacing,
+                },
+            },
+        },
+        single_arena=old_config['single_arena'],
+    )
+
+    if (brackets := old_config.get('brackets')) is not None:
+        new_config['brackets'] = brackets
+
+    return new_config
+
+
+def modernise_knockout_config_if_needed(
+    config: ScheduleKnockoutData | LegacyScheduleKnockoutData,
+) -> ScheduleKnockoutData:
+    if 'scheduler' in config:
+        return cast(ScheduleKnockoutData, config)
+
+    if config.get('static'):
+        return ScheduleStaticKnockoutData(scheduler='static')
+
+    if 'single_arena' in config:
+        return modernise_automatic_knockout_config(
+            cast(LegacyScheduleKnockoutData, config),
+        )
+
+    raise ValueError("Unknown static knockout scheduler config structure")

--- a/sr/comp/knockout_scheduler/exceptions.py
+++ b/sr/comp/knockout_scheduler/exceptions.py
@@ -1,0 +1,10 @@
+class InvalidSeedError(ValueError):
+    pass
+
+
+class InvalidReferenceError(ValueError):
+    pass
+
+
+class WrongNumberOfTeamsError(ValueError):
+    pass

--- a/sr/comp/knockout_scheduler/static_scheduler.py
+++ b/sr/comp/knockout_scheduler/static_scheduler.py
@@ -26,23 +26,16 @@ from .base_scheduler import (
     BaseKnockoutScheduler,
     DEFAULT_KNOCKOUT_BRACKET_NAME,
 )
+from .exceptions import (
+    InvalidReferenceError,
+    InvalidSeedError,
+    WrongNumberOfTeamsError,
+)
 from .types import ScheduleHost
 
 
 class StaticKnockoutScheduleData(BaseKnockoutScheduleData):
     static_knockout: StaticKnockoutData
-
-
-class InvalidSeedError(ValueError):
-    pass
-
-
-class InvalidReferenceError(ValueError):
-    pass
-
-
-class WrongNumberOfTeamsError(ValueError):
-    pass
 
 
 def parse_team_ref(team_ref: str) -> tuple[int, int, int]:

--- a/sr/comp/knockout_scheduler/structured_scheduler.py
+++ b/sr/comp/knockout_scheduler/structured_scheduler.py
@@ -23,7 +23,7 @@ from .base_scheduler import (
     BaseKnockoutScheduler,
     DEFAULT_KNOCKOUT_BRACKET_NAME,
 )
-from .static_scheduler import (
+from .exceptions import (
     InvalidReferenceError,
     InvalidSeedError,
     WrongNumberOfTeamsError,

--- a/sr/comp/knockout_scheduler/structured_scheduler.py
+++ b/sr/comp/knockout_scheduler/structured_scheduler.py
@@ -11,7 +11,7 @@ from ..teams import Team
 from ..types import (
     ArenaName,
     MatchNumber,
-    ScheduleStructuredKnockoutData,
+    ScheduleKnockoutRoundSpacingData,
     StructuredKnockoutData,
     StructuredMatchInfo,
     StructuredMatchTeamReference,
@@ -32,7 +32,7 @@ from .types import ScheduleHost
 
 
 class StructuredKnockoutScheduleData(BaseKnockoutScheduleData):
-    schedule: ScheduleStructuredKnockoutData
+    round_spacing: ScheduleKnockoutRoundSpacingData
     structure: StructuredKnockoutData
 
 
@@ -213,9 +213,7 @@ class StructuredScheduler(BaseKnockoutScheduler[StructuredKnockoutScheduleData])
 
     def add_knockouts(self) -> None:
         rounds_info = self.config['structure']['rounds']
-        rounds_spacing = RoundsSpacing.parse(
-            self.config['schedule']['round_spacing'],
-        )
+        rounds_spacing = RoundsSpacing.parse(self.config['round_spacing'])
 
         for round_num, round_info in sorted(rounds_info.items()):
             rounds_remaining = len(rounds_info) - round_num - 1

--- a/sr/comp/knockout_scheduler/structured_scheduler.py
+++ b/sr/comp/knockout_scheduler/structured_scheduler.py
@@ -1,0 +1,240 @@
+"""An automatic seeded knockout schedule."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from ..match_period import KnockoutMatch, MatchSlot, MatchType
+from ..match_period_clock import MatchPeriodClock, Spacing
+from ..scores import Scores
+from ..teams import Team
+from ..types import (
+    ArenaName,
+    MatchNumber,
+    ScheduleStructuredKnockoutData,
+    StructuredKnockoutData,
+    StructuredMatchInfo,
+    StructuredMatchTeamReference,
+    TLA,
+)
+from .automatic_scheduler import RoundsSpacing
+from .base_scheduler import (
+    BaseKnockoutScheduleData,
+    BaseKnockoutScheduler,
+    DEFAULT_KNOCKOUT_BRACKET_NAME,
+)
+from .static_scheduler import (
+    InvalidReferenceError,
+    InvalidSeedError,
+    WrongNumberOfTeamsError,
+)
+from .types import ScheduleHost
+
+
+class StructuredKnockoutScheduleData(BaseKnockoutScheduleData):
+    schedule: ScheduleStructuredKnockoutData
+    structure: StructuredKnockoutData
+
+
+class StructuredScheduler(BaseKnockoutScheduler[StructuredKnockoutScheduleData]):
+    """
+    A class that can be used to generate a knockout schedule based on a structure.
+
+    :param schedule: The league schedule.
+    :param scores: The scores.
+    :param arenas: The arenas.
+    :param num_teams_per_arena: The usual number of teams per arena.
+    :param teams: The teams.
+    :param config: Custom configuration for the knockout scheduler.
+    """
+
+    def __init__(
+        self,
+        schedule: ScheduleHost,
+        scores: Scores,
+        arenas: Iterable[ArenaName],
+        num_teams_per_arena: int,
+        teams: Mapping[TLA, Team],
+        config: StructuredKnockoutScheduleData,
+    ) -> None:
+        super().__init__(schedule, scores, arenas, num_teams_per_arena, teams, config)
+
+        self.clock = MatchPeriodClock(self.period, self.schedule.delays)
+
+        # Collect a list of the teams eligible for the knockouts, in seeded order.
+        self._knockout_seeds = self._get_seeds()
+
+        # Lookup by structure reference, purely for internal lookup
+        self._matches: dict[tuple[int, int, ArenaName], KnockoutMatch] = {}
+
+    def get_team(self, team_ref: StructuredMatchTeamReference | None) -> TLA | None:
+        if team_ref is None:
+            return None
+
+        if 'seed' in team_ref:
+            seed = team_ref['seed']  # type: ignore[typeddict-item]
+            # seed numbers are 1 based
+            if seed < 1:
+                raise InvalidSeedError(f"Invalid seed {team_ref!r} (seed numbers start at 1)")
+            seed -= 1
+            try:
+                return self._knockout_seeds[seed]
+            except IndexError:
+                raise InvalidSeedError(
+                    "Cannot reference seed {}, there are only {} eligible teams!".format(
+                        team_ref,
+                        len(self._knockout_seeds),
+                    ),
+                ) from None
+
+        assert 'seed' not in team_ref, "Unknown team reference format"
+        assert 'round' in team_ref, "Unknown team reference format"
+
+        # get a position from a match
+
+        arena = team_ref['arena']
+        if arena not in self.arenas:
+            raise InvalidReferenceError(f"Reference {team_ref!r} to unknown arena!")
+
+        round_num = team_ref['round']
+        slot_num = team_ref['slot']
+        match_ref = (round_num, slot_num, arena)
+        pos = team_ref['position']
+
+        try:
+            match = self._matches[match_ref]
+        except KeyError:
+            rounds_info = self.config['structure']['rounds']
+
+            if round_num not in rounds_info:
+                raise InvalidReferenceError(
+                    f"Reference {team_ref!r} to unknown match round! "
+                    f"(Cannot refer to round {round_num} when there are only "
+                    f"{len(rounds_info)} rounds; note that round numbers "
+                    "are 0-indexed)",
+                ) from None
+
+            slots = rounds_info[round_num]['match_slots']
+            if slot_num not in slots:
+                raise InvalidReferenceError(
+                    f"Reference {team_ref!r} to unknown match slot! "
+                    f"(Cannot refer to slot {slot_num} when there are only "
+                    f"{len(slots)} slot(s) in round {round_num}; "
+                    "note that slot numbers are 0-indexed)",
+                ) from None
+
+            matches = slots[slot_num]
+            if arena not in matches:
+                raise InvalidReferenceError(
+                    f"Reference {team_ref!r} to unknown arena! "
+                    f"(Cannot refer to arena {arena} within slot {slot_num} which "
+                    f"only has matches in {list(matches.keys())}",
+                ) from None
+
+            raise RuntimeError(
+                f"Reference {team_ref!r} to unknown match, yet all elements appear valid!",
+            )
+
+        try:
+            ranking = self.get_ranking(match)
+            return ranking[pos]
+        except IndexError:
+            raise InvalidReferenceError(
+                f"Reference {team_ref!r} to invalid ranking! "
+                f"Position {pos!r} does not exist in match \"{match.display_name}\". "
+                f"Available positions: {tuple(range(len(ranking)))}.",
+            ) from None
+
+    def _apply_spacing(self, spacing: Spacing) -> None:
+        self.clock.apply_spacing(
+            spacing=spacing,
+            recover_time=self.schedule._recover_time,
+        )
+
+    def _add_match_slot(
+        self,
+        round_num: int,
+        slot_num: int,
+        slot_info: Mapping[ArenaName, StructuredMatchInfo],
+        rounds_remaining: int,
+    ) -> None:
+        new_matches = {}
+
+        for arena, match_info in sorted(slot_info.items()):
+            start_time = self.clock.current_time
+            end_time = start_time + self.schedule.match_duration
+            num = MatchNumber(len(self.schedule.matches))
+
+            teams = [
+                self.get_team(team_ref)
+                for team_ref in match_info['teams']
+            ]
+
+            if len(teams) != self.num_teams_per_arena:
+                raise WrongNumberOfTeamsError(
+                    f"Unexpected number of teams in match {num} (round {round_num}); "
+                    f"got {len(teams)}, expecting {self.num_teams_per_arena}." + (
+                        " Fill any expected empty places with `null`."
+                        if len(teams) < self.num_teams_per_arena
+                        else ""
+                    ),
+                )
+
+            display_name = self.get_match_display_name(
+                rounds_remaining,
+                round_num,
+                num,
+            )
+
+            # allow overriding the name
+            override_name = match_info.get('display_name')
+            if override_name is not None:
+                display_name = f"{override_name} (#{num})"
+
+            is_final = rounds_remaining == 0
+            match = KnockoutMatch(
+                num,
+                display_name,
+                arena,
+                teams,
+                start_time,
+                end_time,
+                MatchType.knockout,
+                use_resolved_ranking=not is_final,
+                knockout_bracket=match_info.get('bracket', DEFAULT_KNOCKOUT_BRACKET_NAME),
+            )
+            self.knockout_rounds[-1].append(match)
+            self._matches[round_num, slot_num, arena] = match
+            new_matches[arena] = match
+
+        self.clock.advance_time(self.schedule.match_duration)
+        self.schedule.matches.append(MatchSlot(new_matches))
+        self.period.matches.append(MatchSlot(new_matches))
+
+    def add_knockouts(self) -> None:
+        rounds_info = self.config['structure']['rounds']
+        rounds_spacing = RoundsSpacing.parse(
+            self.config['schedule']['round_spacing'],
+        )
+
+        for round_num, round_info in sorted(rounds_info.items()):
+            rounds_remaining = len(rounds_info) - round_num - 1
+            self._append_knockout_round(
+                rounds_remaining,
+                name=round_info.get('display_name'),
+            )
+
+            for slot_num, slot_info in sorted(round_info['match_slots'].items()):
+                self._add_match_slot(
+                    round_num,
+                    slot_num,
+                    slot_info,
+                    rounds_remaining,
+                )
+
+            if rounds_remaining > 0:
+                # Add the delay between rounds
+                self._apply_spacing(rounds_spacing.get(
+                    round_num=len(self.knockout_rounds),
+                    rounds_remaining=rounds_remaining,
+                ))

--- a/sr/comp/matches.py
+++ b/sr/comp/matches.py
@@ -22,6 +22,8 @@ from .knockout_scheduler import (
     modernise_knockout_config_if_needed,
     StaticKnockoutScheduleData,
     StaticScheduler,
+    StructuredKnockoutScheduleData,
+    StructuredScheduler,
 )
 from .knockout_scheduler.base_scheduler import BaseKnockoutScheduler
 from .match_period import Delay, Match, MatchPeriod, MatchSlot, MatchType
@@ -32,6 +34,7 @@ from .types import (
     ArenaName,
     DelayData,
     ExtraSpacingData,
+    KnockoutData,
     LeagueMatches,
     MatchNumber,
     MatchSlotLengthsData,
@@ -119,6 +122,7 @@ class MatchSchedule:
         cls: type[TSchedule],
         config_fname: Path,
         league_fname: Path,
+        knockout_fname: Path,
         scores: Scores,
         arenas: Mapping[ArenaName, Arena],
         num_teams_per_arena: int,
@@ -157,6 +161,21 @@ class MatchSchedule:
                     'static_knockout': StaticScheduler.modernise_config_if_needed(
                         y['static_knockout'],
                     ),
+                }),
+            )
+        elif knockout_config['scheduler'] == 'structured':
+            structured_knockout: KnockoutData = yaml_loader.load(knockout_fname)
+            k = StructuredScheduler(
+                schedule,
+                scores,
+                arenas,
+                num_teams_per_arena,
+                teams,
+                config=StructuredKnockoutScheduleData({
+                    'match_periods': y['match_periods'],
+                    'brackets': knockout_config.get('brackets', ()),
+                    'schedule': knockout_config,
+                    'structure': structured_knockout['structured_knockout'],
                 }),
             )
         elif knockout_config['scheduler'] == 'automatic':

--- a/sr/comp/matches.py
+++ b/sr/comp/matches.py
@@ -174,7 +174,7 @@ class MatchSchedule:
                 config=StructuredKnockoutScheduleData({
                     'match_periods': y['match_periods'],
                     'brackets': knockout_config.get('brackets', ()),
-                    'schedule': knockout_config,
+                    'round_spacing': knockout_config['round_spacing'],
                     'structure': structured_knockout['structured_knockout'],
                 }),
             )

--- a/sr/comp/matches.py
+++ b/sr/comp/matches.py
@@ -19,6 +19,7 @@ from .knockout_scheduler import (
     KnockoutBracket,
     KnockoutRound,
     KnockoutScheduler,
+    modernise_knockout_config_if_needed,
     StaticKnockoutScheduleData,
     StaticScheduler,
 )
@@ -140,8 +141,10 @@ class MatchSchedule:
 
         schedule = cls(y, league, teams, num_teams_per_arena)
 
+        knockout_config = modernise_knockout_config_if_needed(y['knockout'])
+
         k: BaseKnockoutScheduler[Any]
-        if y['knockout'].get('static', False):
+        if knockout_config['scheduler'] == 'static':
             k = StaticScheduler(
                 schedule,
                 scores,
@@ -150,13 +153,13 @@ class MatchSchedule:
                 teams,
                 config=StaticKnockoutScheduleData({
                     'match_periods': y['match_periods'],
-                    'brackets': y['knockout'].get('brackets', ()),
+                    'brackets': knockout_config.get('brackets', ()),
                     'static_knockout': StaticScheduler.modernise_config_if_needed(
                         y['static_knockout'],
                     ),
                 }),
             )
-        else:
+        elif knockout_config['scheduler'] == 'automatic':
             k = KnockoutScheduler(
                 schedule,
                 scores,
@@ -165,9 +168,13 @@ class MatchSchedule:
                 teams,
                 config=AutoKnockoutScheduleData({
                     'match_periods': y['match_periods'],
-                    'brackets': y['knockout'].get('brackets', ()),
-                    'knockout': y['knockout'],
+                    'brackets': knockout_config.get('brackets', ()),
+                    'knockout': knockout_config,
                 }),
+            )
+        else:
+            raise ValueError(
+                f"Unsupported knockout scheduler type {knockout_config['scheduler']!r}",
             )
 
         k.add_knockouts()

--- a/sr/comp/types.py
+++ b/sr/comp/types.py
@@ -459,7 +459,7 @@ StructuredMatchTeamReference = Union[
 
 
 class StructuredMatchInfo(TypedDict):
-    teams: list[StructuredMatchTeamReference]
+    teams: list[StructuredMatchTeamReference | None]
     display_name: NotRequired[str]
     bracket: NotRequired[str]
 

--- a/sr/comp/types.py
+++ b/sr/comp/types.py
@@ -4,6 +4,7 @@ import datetime
 from collections.abc import Mapping
 from typing import (
     Collection,
+    Literal,
     NewType,
     Protocol,
     runtime_checkable,
@@ -254,15 +255,7 @@ class KnockoutBracketData(TypedDict):
     """The internal identifier of a knockout bracket"""
 
 
-class ScheduleKnockoutData(TypedDict):
-    round_spacing: int
-    """Time delay between rounds (in seconds)"""
-    final_delay: int
-    """Extra delay before the final (for build-up and rotating, in seconds)"""
-    arity: NotRequired[int]
-    """Number of teams taking part"""
-    single_arena: KnockoutSingleArenaData
-
+class _BracketsMixin(TypedDict):
     brackets: NotRequired[list[KnockoutBracketData]]
     """
     Brackets which make up the knockout.
@@ -272,8 +265,61 @@ class ScheduleKnockoutData(TypedDict):
     This currently has no bearing on the actual matches and is purely a display consideration.
     """
 
+
+class LegacyScheduleKnockoutData(TypedDict, _BracketsMixin):
+    round_spacing: int
+    """Time delay between rounds (in seconds)"""
+    final_delay: int
+    """Extra delay before the final (for build-up and rotating, in seconds)"""
+    arity: NotRequired[int]
+    """Number of teams taking part"""
+    single_arena: KnockoutSingleArenaData
+
     static: NotRequired[bool]
     """Whether or not to use the static knockout scheduler (rather than the automatic one)"""
+
+
+class KnockoutRoundSpacingData(TypedDict):
+    """
+    The spacing between knockout rounds, all in seconds.
+
+    nominal == delay_flex + minimum
+    """
+
+    delay_flex: int
+    """How much delay time to absorb (in seconds)"""
+
+    minimum: int
+    """Minimum delay between rounds (in seconds)"""
+
+    nominal: int
+    """Default time delay between rounds (in seconds)"""
+
+
+class ScheduleKnockoutRoundSpacingData(TypedDict):
+    default: KnockoutRoundSpacingData
+    overrides: NotRequired[dict[int, KnockoutRoundSpacingData]]
+
+
+class ScheduleAutomaticKnockoutData(TypedDict, _BracketsMixin):
+    scheduler: Literal['automatic']
+
+    round_spacing: ScheduleKnockoutRoundSpacingData
+
+    arity: NotRequired[int]
+    """Number of teams taking part"""
+
+    single_arena: KnockoutSingleArenaData
+
+
+class ScheduleStaticKnockoutData(TypedDict, _BracketsMixin):
+    scheduler: Literal['static']
+
+
+ScheduleKnockoutData = Union[
+    ScheduleAutomaticKnockoutData,
+    ScheduleStaticKnockoutData,
+]
 
 
 StaticMatchTeamReference = NewType('StaticMatchTeamReference', str)
@@ -352,7 +398,7 @@ class ScheduleData(TypedDict):
     tiebreaker: NotRequired[datetime.datetime]
 
     league: ScheduleLeagueData
-    knockout: ScheduleKnockoutData
+    knockout: ScheduleKnockoutData | LegacyScheduleKnockoutData
 
     static_knockout: NotRequired[StaticKnockoutData | LegacyStaticKnockoutData]
 

--- a/sr/comp/types.py
+++ b/sr/comp/types.py
@@ -316,9 +316,16 @@ class ScheduleStaticKnockoutData(TypedDict, _BracketsMixin):
     scheduler: Literal['static']
 
 
+class ScheduleStructuredKnockoutData(TypedDict, _BracketsMixin):
+    scheduler: Literal['structured']
+
+    round_spacing: ScheduleKnockoutRoundSpacingData
+
+
 ScheduleKnockoutData = Union[
     ScheduleAutomaticKnockoutData,
     ScheduleStaticKnockoutData,
+    ScheduleStructuredKnockoutData,
 ]
 
 
@@ -401,6 +408,85 @@ class ScheduleData(TypedDict):
     knockout: ScheduleKnockoutData | LegacyScheduleKnockoutData
 
     static_knockout: NotRequired[StaticKnockoutData | LegacyStaticKnockoutData]
+
+
+class StructuredSeedReference(TypedDict):
+    """
+    A reference to a seeded team for pulling into a knockout match.
+
+    Seeds are strictly positive integers in ``range(1, N_TEAMS + 1)``.
+    """
+    seed: int
+
+
+class StructuredMatchTeamPositionReference(TypedDict):
+    """
+    A reference to a team based on their position in the results of a knockout
+    match.
+    """
+
+    round: int  # noqa: A003
+    """
+    The round containing the match to reference.
+
+    0-based index matching the original structure definition.
+    """
+
+    slot: int
+    """
+    The slot number within the structure containing the team to reference.
+
+    0-based index matching the original structure definition.
+    """
+
+    arena: ArenaName
+    """
+    The arena of the match containing the team to reference.
+    """
+
+    position: int
+    """
+    The position within the results of the referred match to pull into the current match.
+
+    0-based index, the winners of the referred match have position ``0``.
+    """
+
+
+StructuredMatchTeamReference = Union[
+    StructuredSeedReference,
+    StructuredMatchTeamPositionReference,
+]
+
+
+class StructuredMatchInfo(TypedDict):
+    teams: list[StructuredMatchTeamReference]
+    display_name: NotRequired[str]
+    bracket: NotRequired[str]
+
+
+class StructuredKnockoutRoundData(TypedDict):
+    display_name: NotRequired[str]
+    match_slots: Mapping[int, Mapping[ArenaName, StructuredMatchInfo]]
+    """
+    A mapping describing the match slots in the round.
+
+    First level keys should be 0-indexed numbers identifying the match slot
+    within the round. Second level keys are arena names. Slot numbers start from
+    zero for each round.
+    """
+
+
+class StructuredKnockoutData(TypedDict):
+    rounds: Mapping[int, StructuredKnockoutRoundData]
+    """
+    A mapping describing the rounds in the knockout.
+
+    Keys should be 0-indexed numbers identifying the round.
+    """
+
+
+class KnockoutData(TypedDict):
+    structured_knockout: StructuredKnockoutData
 
 
 AwardsData = NewType('AwardsData', dict[str, Union[TLA, list[TLA]]])

--- a/tests/test_knockout_scheduler.py
+++ b/tests/test_knockout_scheduler.py
@@ -8,7 +8,11 @@ from unittest import mock
 
 from league_ranker import RankedPosition
 
-from sr.comp.knockout_scheduler import KnockoutScheduler, UNKNOWABLE_TEAM
+from sr.comp.knockout_scheduler import (
+    KnockoutScheduler,
+    modernise_automatic_knockout_config,
+    UNKNOWABLE_TEAM,
+)
 from sr.comp.knockout_scheduler.automatic_scheduler import (
     AutoKnockoutScheduleData,
 )
@@ -20,7 +24,8 @@ from sr.comp.types import (
     GamePoints,
     MatchId,
     MatchPeriodData,
-    ScheduleKnockoutData,
+    ScheduleAutomaticKnockoutData,
+    ScheduleKnockoutRoundSpacingData,
     TLA,
 )
 
@@ -36,8 +41,10 @@ def mock_first_round_seeding(side_effect):
 
 def get_scheduler(
     matches: list[MatchSlot] | None = None,
+    *,
     positions: LeaguePositions | None = None,
     knockout_positions: Mapping[MatchId, Mapping[TLA, RankedPosition]] | None = None,
+    round_spacing: ScheduleKnockoutRoundSpacingData | None = None,
     league_game_points: dict[MatchId, Mapping[TLA, GamePoints]] | None = None,
     delays: list[Delay] | None = None,
     teams: dict[TLA, Team] | None = None,
@@ -73,14 +80,17 @@ def get_scheduler(
         'start_time': datetime(2014, 3, 27, 13),
         'end_time':   datetime(2014, 3, 27, 17, 30),  # noqa:E241
     }
-    knockout_config: ScheduleKnockoutData = {
+    knockout_config: ScheduleAutomaticKnockoutData
+    knockout_config = modernise_automatic_knockout_config({
         'round_spacing': 30,
         'final_delay': 12,
         'single_arena': {
             'rounds': 3,
             'arenas': [ArenaName('A')],
         },
-    }
+    })
+    if round_spacing:
+        knockout_config['round_spacing'] = round_spacing
     config: AutoKnockoutScheduleData = {
         'match_periods': {'knockout': [period_config]},
         'brackets': (),
@@ -514,3 +524,97 @@ class KnockoutSchedulerTests(unittest.TestCase):
         ]
 
         self.assertEqual(expected_times, start_times, "Wrong start times")
+
+    def test_timings_with_delays_later_absorbed(self):
+        positions = OrderedDict()
+        for i in range(16):
+            positions[f'team-{i}'] = i
+
+        delays = [
+            Delay(
+                time=datetime(2014, 3, 27, 13, 2),
+                delay=timedelta(minutes=2),
+            ),
+            Delay(
+                time=datetime(2014, 3, 27, 13, 12),
+                delay=timedelta(minutes=2),
+            ),
+        ]
+
+        scheduler = get_scheduler(
+            positions=positions,
+            delays=delays,
+            round_spacing={
+                'default': {
+                    'delay_flex': 150,
+                    'minimum': 150,
+                    'nominal': 300,
+                },
+                'overrides': {
+                    -1: {
+                        'delay_flex': 240,
+                        'minimum': 102,
+                        'nominal': 342,
+                    },
+                },
+            },
+        )
+        scheduler.add_knockouts()
+
+        knockout_rounds = scheduler.knockout_rounds
+        num_rounds = len(knockout_rounds)
+
+        self.assertEqual(3, num_rounds, "Should be quarters, semis and finals")
+
+        start_times = [m['A'].start_time for m in scheduler.period.matches]
+
+        expected_times = [
+            # Quarter finals
+            datetime(2014, 3, 27, 13, 0),
+            datetime(2014, 3, 27, 13, 7),   # affected by first delay only
+            datetime(2014, 3, 27, 13, 14),  # affected by both delays
+            datetime(2014, 3, 27, 13, 19),
+
+            # 5 minute gap, with 2:30 of flex -- all the flex is used up
+
+            # Semi finals
+            datetime(2014, 3, 27, 13, 26, 30),
+            datetime(2014, 3, 27, 13, 31, 30),
+
+            # 5:42 gap, with 4 minutes of flex -- some of the flex is used
+            # we're back on track
+
+            # Final
+            datetime(2014, 3, 27, 13, 40, 42),
+        ]
+
+        self.assertEqual(expected_times, start_times, "Wrong start times")
+
+        self.assertEqual(
+            [
+                Delay(
+                    time=datetime(2014, 3, 27, 13, 2),
+                    delay=timedelta(minutes=2),
+                ),
+                Delay(
+                    time=datetime(2014, 3, 27, 13, 12),
+                    delay=timedelta(minutes=2),
+                ),
+                Delay(
+                    time=datetime(2014, 3, 27, 13, 24),
+                    delay=timedelta(minutes=-2.5),
+                ),
+                Delay(
+                    time=datetime(2014, 3, 27, 13, 36, 30),
+                    delay=timedelta(minutes=-1.5),
+                ),
+            ],
+            scheduler.schedule.delays,
+            "Should have updated the schedule with recovered time",
+        )
+
+        self.assertEqual(
+            timedelta(0),
+            sum((x.delay for x in scheduler.schedule.delays), start=timedelta(0)),
+            "Final delay should be zero",
+        )

--- a/tests/test_structured_knockout_scheduler.py
+++ b/tests/test_structured_knockout_scheduler.py
@@ -1,0 +1,776 @@
+from __future__ import annotations
+
+import itertools
+import unittest
+from collections import OrderedDict
+from collections.abc import Collection, Mapping, Sequence
+from datetime import datetime, timedelta
+from unittest import mock
+
+from league_ranker import RankedPosition
+
+from sr.comp.knockout_scheduler import StructuredScheduler, UNKNOWABLE_TEAM
+from sr.comp.knockout_scheduler.base_scheduler import (
+    DEFAULT_KNOCKOUT_BRACKET_NAME,
+)
+from sr.comp.knockout_scheduler.exceptions import (
+    InvalidReferenceError,
+    InvalidSeedError,
+    WrongNumberOfTeamsError,
+)
+from sr.comp.knockout_scheduler.structured_scheduler import (
+    StructuredKnockoutScheduleData,
+)
+from sr.comp.match_period import (
+    Delay,
+    KnockoutMatch,
+    Match,
+    MatchSlot,
+    MatchType,
+)
+from sr.comp.scores import LeaguePosition, LeaguePositions
+from sr.comp.teams import Team
+from sr.comp.types import (
+    ArenaName,
+    GamePoints,
+    MatchId,
+    MatchNumber,
+    MatchPeriodData,
+    ScheduleKnockoutRoundSpacingData,
+    StructuredKnockoutData,
+    StructuredKnockoutRoundData,
+    StructuredMatchTeamPositionReference,
+    StructuredSeedReference,
+    TLA,
+)
+
+from .factories import build_match, FakeSchedule
+
+TLAs = ['AAA', 'BBB', 'CCC', 'DDD', 'EEE', 'FFF', 'GGG', 'HHH', 'III', 'JJJ']
+
+ARENA_A = ArenaName('A')
+ARENA_B = ArenaName('B')
+
+
+def _team_ref(
+    round: int,  # noqa: A002
+    slot: int,
+    arena: str,
+    position: int,
+) -> StructuredMatchTeamPositionReference:
+    return {
+        'round': round,
+        'slot': slot,
+        'arena': ArenaName(arena),
+        'position': position,
+    }
+
+
+def get_round_spacing_data() -> ScheduleKnockoutRoundSpacingData:
+    return {
+        'default': {
+            'delay_flex': 0,
+            'minimum': 300,
+            'nominal': 300,
+        },
+        'overrides': {
+            -1: {
+                'delay_flex': 300,
+                'minimum': 300,
+                'nominal': 600,
+            },
+        },
+    }
+
+
+def get_four_team_structure() -> tuple[int, StructuredKnockoutData]:
+    rounds: Mapping[int, StructuredKnockoutRoundData] = {
+        0: {
+            'match_slots': {
+                0: {
+                    ARENA_A: {
+                        'display_name': "Qualifier A",
+                        'teams': [
+                            {'seed': 3},
+                            {'seed': 5},
+                            {'seed': 8},
+                            {'seed': 10},
+                        ],
+                    },
+                    ARENA_B: {
+                        'display_name': "Qualifier B",
+                        'teams': [
+                            {'seed': 4},
+                            {'seed': 6},
+                            {'seed': 7},
+                            {'seed': 9},
+                        ],
+                    },
+                },
+            },
+        },
+        1: {
+            'match_slots': {
+                0: {
+                    ARENA_A: {
+                        'display_name': "Semi A 0",
+                        'teams': [
+                            {'seed': 2},
+                            _team_ref(round=0, slot=0, arena=ARENA_A, position=0),
+                            _team_ref(round=0, slot=0, arena=ARENA_A, position=2),
+                            _team_ref(round=0, slot=0, arena=ARENA_B, position=1),
+                        ],
+                    },
+                },
+                1: {
+                    ARENA_A: {
+                        'display_name': "Semi A 1",
+                        'teams': [
+                            {'seed': 1},
+                            _team_ref(round=0, slot=0, arena=ARENA_A, position=1),
+                            _team_ref(round=0, slot=0, arena=ARENA_B, position=0),
+                            _team_ref(round=0, slot=0, arena=ARENA_B, position=2),
+                        ],
+                    },
+                },
+            },
+        },
+        2: {
+            'match_slots': {
+                0: {
+                    ARENA_A: {
+                        'teams': [
+                            _team_ref(round=1, slot=0, arena=ARENA_A, position=0),
+                            _team_ref(round=1, slot=0, arena=ARENA_A, position=1),
+                            _team_ref(round=1, slot=1, arena=ARENA_A, position=0),
+                            _team_ref(round=1, slot=1, arena=ARENA_A, position=1),
+                        ],
+                    },
+                },
+            },
+        },
+    }
+
+    return 4, {'rounds': rounds}
+
+
+def get_two_team_structure() -> tuple[int, StructuredKnockoutData]:
+    rounds: Mapping[int, StructuredKnockoutRoundData] = {
+        0: {
+            'match_slots': {
+                0: {
+                    ARENA_A: {
+                        'display_name': "Qualifier A",
+                        'teams': [
+                            {'seed': 3},
+                            {'seed': 5},
+                        ],
+                    },
+                    ARENA_B: {
+                        'display_name': "Qualifier B",
+                        'teams': [
+                            {'seed': 4},
+                            {'seed': 6},
+                        ],
+                    },
+                },
+            },
+        },
+        1: {
+            'match_slots': {
+                0: {
+                    ARENA_A: {
+                        'display_name': "Semi A 0",
+                        'teams': [
+                            {'seed': 1},
+                            _team_ref(round=0, slot=0, arena=ARENA_A, position=0),
+                        ],
+                    },
+                },
+                1: {
+                    ARENA_A: {
+                        'display_name': "Semi A 1",
+                        'teams': [
+                            {'seed': 2},
+                            _team_ref(round=0, slot=0, arena=ARENA_B, position=0),
+                        ],
+                    },
+                },
+            },
+        },
+        2: {
+            'match_slots': {
+                0: {
+                    ARENA_A: {
+                        'teams': [
+                            _team_ref(round=1, slot=0, arena=ARENA_A, position=0),
+                            _team_ref(round=1, slot=1, arena=ARENA_A, position=0),
+                        ],
+                    },
+                },
+            },
+        },
+    }
+
+    return 2, {'rounds': rounds}
+
+
+def get_scheduler(
+    structure_data: tuple[int, StructuredKnockoutData],
+    round_spacing: ScheduleKnockoutRoundSpacingData | None = None,
+    matches: Collection[Mapping[ArenaName, Match]] | None = None,
+    positions: LeaguePositions | None = None,
+    knockout_positions: Mapping[MatchId, Mapping[TLA, RankedPosition]] | None = None,
+    league_game_points: dict[MatchId, Mapping[TLA, GamePoints]] | None = None,
+    delays: list[Delay] | None = None,
+    teams: dict[TLA, Team] | None = None,
+) -> StructuredScheduler:
+    round_spacing = round_spacing or get_round_spacing_data()
+    matches = matches or []
+    delays = delays or []
+    match_duration = timedelta(minutes=5)
+    league_game_points = league_game_points or {}
+    knockout_positions = knockout_positions or {}
+
+    if not positions:
+        positions = OrderedDict()
+        positions[TLA('AAA')] = LeaguePosition(1)
+        positions[TLA('BBB')] = LeaguePosition(2)
+        positions[TLA('CCC')] = LeaguePosition(3)
+        positions[TLA('DDD')] = LeaguePosition(4)
+        positions[TLA('EEE')] = LeaguePosition(5)
+        positions[TLA('FFF')] = LeaguePosition(6)
+        positions[TLA('GGG')] = LeaguePosition(7)
+        positions[TLA('HHH')] = LeaguePosition(8)
+        positions[TLA('III')] = LeaguePosition(9)
+        positions[TLA('JJJ')] = LeaguePosition(10)
+
+    if sorted(positions.keys()) != TLAs:
+        raise ValueError("Must use common TLAs")
+
+    if teams is None:
+        teams = {x: Team(x, x, False, None) for x in positions.keys()}
+
+    league_schedule = FakeSchedule(
+        matches=[MatchSlot(x) for x in matches],
+        delays=delays,
+        match_duration=match_duration,
+    )
+    league_scores = mock.Mock(positions=positions, game_points=league_game_points)
+    knockout_scores = mock.Mock(resolved_positions=knockout_positions)
+    scores = mock.Mock(league=league_scores, knockout=knockout_scores)
+
+    num_teams_per_arena, structure = structure_data
+
+    period_config: MatchPeriodData = {
+        "description": "A description of the period",
+        "start_time": datetime(2014, 4, 27, 14, 30),
+        "end_time": datetime(2014, 4, 27, 17, 30),
+    }
+    config: StructuredKnockoutScheduleData = {
+        'match_periods': {'knockout': [period_config]},
+        'brackets': (),
+        'structure': structure,
+        'round_spacing': round_spacing,
+    }
+    arenas = [ARENA_A, ARENA_B]
+
+    scheduler = StructuredScheduler(
+        league_schedule,
+        scores,
+        arenas,
+        num_teams_per_arena,
+        teams,
+        config,
+    )
+    return scheduler
+
+
+def build_5_matches(
+    places: Sequence[Collection[TLA | str | None]],
+    *,
+    first_match_number: int = 0,
+) -> list[MatchSlot]:
+    if len(places) != 5:
+        raise ValueError("Bad list of team places")
+
+    match_numbers = iter(itertools.count(start=first_match_number))
+
+    def _convert_teams(teams: Collection[TLA | str | None]) -> list[TLA | None]:
+        return [TLA(x) if x is not None else None for x in teams]
+
+    return [
+        MatchSlot({
+            ARENA_A: KnockoutMatch(
+                MatchNumber(n := next(match_numbers)),
+                f"Qualifier A (#{n})",
+                ARENA_A,
+                _convert_teams(places[0]),
+                start_time=datetime(2014, 4, 27, 14, 30),
+                end_time=datetime(2014, 4, 27, 14, 35),
+                type=MatchType.knockout,
+                use_resolved_ranking=True,
+                knockout_bracket=DEFAULT_KNOCKOUT_BRACKET_NAME,
+            ),
+            ARENA_B: KnockoutMatch(
+                MatchNumber(n),
+                f"Qualifier B (#{n})",
+                ARENA_B,
+                _convert_teams(places[1]),
+                start_time=datetime(2014, 4, 27, 14, 30),
+                end_time=datetime(2014, 4, 27, 14, 35),
+                type=MatchType.knockout,
+                use_resolved_ranking=True,
+                knockout_bracket=DEFAULT_KNOCKOUT_BRACKET_NAME,
+            ),
+        }),
+        MatchSlot({
+            ARENA_A: KnockoutMatch(
+                MatchNumber(n := next(match_numbers)),
+                f"Semi A 0 (#{n})",
+                ARENA_A,
+                _convert_teams(places[2]),
+                start_time=datetime(2014, 4, 27, 14, 40),
+                end_time=datetime(2014, 4, 27, 14, 45),
+                type=MatchType.knockout,
+                use_resolved_ranking=True,
+                knockout_bracket=DEFAULT_KNOCKOUT_BRACKET_NAME,
+            ),
+        }),
+        MatchSlot({
+            ARENA_A: KnockoutMatch(
+                MatchNumber(n := next(match_numbers)),
+                f"Semi A 1 (#{n})",
+                ARENA_A,
+                _convert_teams(places[3]),
+                start_time=datetime(2014, 4, 27, 14, 45),
+                end_time=datetime(2014, 4, 27, 14, 50),
+                type=MatchType.knockout,
+                use_resolved_ranking=True,
+                knockout_bracket=DEFAULT_KNOCKOUT_BRACKET_NAME,
+            ),
+        }),
+        MatchSlot({
+            ARENA_A: KnockoutMatch(
+                MatchNumber(n := next(match_numbers)),
+                f"Final (#{n})",
+                ARENA_A,
+                _convert_teams(places[4]),
+                start_time=datetime(2014, 4, 27, 15, 0),
+                end_time=datetime(2014, 4, 27, 15, 5),
+                type=MatchType.knockout,
+                use_resolved_ranking=False,
+                knockout_bracket=DEFAULT_KNOCKOUT_BRACKET_NAME,
+            ),
+        }),
+    ]
+
+
+class StaticKnockoutSchedulerTests(unittest.TestCase):
+    maxDiff = None
+
+    def assertMatches(
+        self,
+        expected_matches: Collection[Mapping[ArenaName, Match]],
+        structure_data: tuple[int, StructuredKnockoutData],
+        round_spacing: ScheduleKnockoutRoundSpacingData | None = None,
+        matches: Collection[Mapping[ArenaName, Match]] | None = None,
+        positions: LeaguePositions | None = None,
+        knockout_positions: Mapping[MatchId, Mapping[TLA, RankedPosition]] | None = None,
+        league_game_points: dict[MatchId, Mapping[TLA, GamePoints]] | None = None,
+        delays: list[Delay] | None = None,
+        teams: dict[TLA, Team] | None = None,
+    ) -> None:
+        scheduler = get_scheduler(
+            structure_data=structure_data,
+            round_spacing=round_spacing,
+            matches=matches,
+            positions=positions,
+            knockout_positions=knockout_positions,
+            league_game_points=league_game_points,
+            delays=delays,
+            teams=teams,
+        )
+        scheduler.add_knockouts()
+
+        period = scheduler.period
+
+        self.assertEqual(
+            expected_matches,
+            period.matches,
+            "Wrong knockout matches",
+        )
+
+    def assertInvalidReference(
+        self,
+        value: StructuredMatchTeamPositionReference,
+        matches: Collection[Mapping[ArenaName, Match]] = (),
+    ) -> None:
+        n_teams, config = get_four_team_structure()
+
+        match_info = config['rounds'][1]['match_slots'][0][ARENA_A]
+        match_info['teams'][0] = value
+
+        self.assertInvalidSchedule(n_teams, config, InvalidReferenceError, matches)
+
+    def assertInvalidSeed(
+        self,
+        value: StructuredSeedReference,
+        matches: Collection[Mapping[ArenaName, Match]] = (),
+    ) -> None:
+        n_teams, config = get_four_team_structure()
+
+        match_info = config['rounds'][1]['match_slots'][0][ARENA_A]
+        match_info['teams'][0] = value
+
+        self.assertInvalidSchedule(n_teams, config, InvalidSeedError, matches)
+
+    def assertInvalidSchedule(
+        self,
+        num_teams_per_arena: int,
+        structure: StructuredKnockoutData,
+        exception_type: type[Exception],
+        matches: Collection[Mapping[ArenaName, Match]] = (),
+        round_spacing: ScheduleKnockoutRoundSpacingData | None = None,
+    ) -> None:
+        with self.assertRaises(exception_type):
+            scheduler = get_scheduler(
+                (num_teams_per_arena, structure),
+                round_spacing=round_spacing,
+                matches=matches,
+            )
+
+            scheduler.add_knockouts()
+
+    def test_four_teams_before(self) -> None:
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{ARENA_A: build_match(arena=ARENA_A)}]
+
+        expected = build_5_matches(
+            places=[[UNKNOWABLE_TEAM] * 4] * 5,
+            first_match_number=1,
+        )
+
+        self.assertMatches(
+            expected,
+            structure_data=get_four_team_structure(),
+            matches=league_matches,
+        )
+
+    def test_four_teams_start(self) -> None:
+        expected_matches = build_5_matches([
+            ['CCC', 'EEE', 'HHH', 'JJJ'],
+            ['DDD', 'FFF', 'GGG', 'III'],
+            ['BBB'] + [UNKNOWABLE_TEAM] * 3,
+            ['AAA'] + [UNKNOWABLE_TEAM] * 3,
+            [UNKNOWABLE_TEAM] * 4,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=get_four_team_structure(),
+        )
+
+    def test_four_teams_start_only_progressing_winner_from_quarters(self) -> None:
+        n_teams, config = get_four_team_structure()
+
+        semis = config['rounds'][1]['match_slots']
+        semis[0][ARENA_A]['teams'][-1] = None
+        semis[1][ARENA_A]['teams'][-1] = None
+
+        expected_matches = build_5_matches([
+            ['CCC', 'EEE', 'HHH', 'JJJ'],
+            ['DDD', 'FFF', 'GGG', 'III'],
+            ['BBB', UNKNOWABLE_TEAM, UNKNOWABLE_TEAM, None],
+            ['AAA', UNKNOWABLE_TEAM, UNKNOWABLE_TEAM, None],
+            [UNKNOWABLE_TEAM] * 4,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=(n_teams, config),
+        )
+
+    def test_four_teams_with_dropout_part_way_through(self) -> None:
+        LAST_QUARTER_FINAL_MATCH_NUM = MatchNumber(1)
+
+        teams = {TLA(x): Team(TLA(x), x, False, None) for x in TLAs}
+        teams[TLA('BBB')] = Team(
+            TLA('BBB'),
+            'BBB',
+            False,
+            dropped_out_after=LAST_QUARTER_FINAL_MATCH_NUM,
+        )
+
+        expected_matches = build_5_matches([
+            ['CCC', 'EEE', 'HHH', 'JJJ'],
+            ['DDD', 'FFF', 'GGG', 'III'],
+            ['BBB'] + [UNKNOWABLE_TEAM] * 3,
+            ['AAA'] + [UNKNOWABLE_TEAM] * 3,
+            [UNKNOWABLE_TEAM] * 4,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=get_four_team_structure(),
+            teams=teams,
+        )
+
+    def test_four_teams_with_dropout_before_start(self) -> None:
+        teams = {TLA(x): Team(TLA(x), x, False, None) for x in TLAs}
+        teams[TLA('BBB')] = Team(TLA('BBB'), 'BBB', False, dropped_out_after=MatchNumber(-1))
+
+        n_teams, config = get_four_team_structure()
+        qualifier_teams = config['rounds'][0]['match_slots'][0][ARENA_A]['teams']
+
+        self.assertEqual({'seed': 10}, qualifier_teams[-1], "Setup self-check failed!")
+        qualifier_teams[-1] = None
+
+        expected_matches = build_5_matches([
+            ['DDD', 'FFF', 'III', None],
+            ['EEE', 'GGG', 'HHH', 'JJJ'],
+            ['CCC'] + [UNKNOWABLE_TEAM] * 3,
+            ['AAA'] + [UNKNOWABLE_TEAM] * 3,
+            [UNKNOWABLE_TEAM] * 4,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=(n_teams, config),
+            teams=teams,
+        )
+
+    def test_four_teams_partial_1(self) -> None:
+        expected_matches = build_5_matches([
+            ['CCC', 'EEE', 'HHH', 'JJJ'],
+            ['DDD', 'FFF', 'GGG', 'III'],
+            ['BBB', 'JJJ', 'EEE', UNKNOWABLE_TEAM],
+            ['AAA', 'HHH', UNKNOWABLE_TEAM, UNKNOWABLE_TEAM],
+            [UNKNOWABLE_TEAM] * 4,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=get_four_team_structure(),
+            knockout_positions={
+                # QF 1
+                (ARENA_A, MatchNumber(0)): OrderedDict([
+                    ('JJJ', RankedPosition(1)),
+                    ('HHH', RankedPosition(2)),
+                    ('EEE', RankedPosition(3)),
+                    ('CCC', RankedPosition(4)),
+                ]),
+            },
+        )
+
+    def test_four_teams_partial_2(self) -> None:
+        expected_matches = build_5_matches([
+            ['CCC', 'EEE', 'HHH', 'JJJ'],
+            ['DDD', 'FFF', 'GGG', 'III'],
+            ['BBB', 'JJJ', 'EEE', 'GGG'],
+            ['AAA', 'HHH', 'III', 'FFF'],
+            [UNKNOWABLE_TEAM] * 4,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=get_four_team_structure(),
+            knockout_positions={
+                # QF 1
+                (ARENA_A, MatchNumber(0)): OrderedDict([
+                    ('JJJ', RankedPosition(1)),
+                    ('HHH', RankedPosition(2)),
+                    ('EEE', RankedPosition(3)),
+                    ('CCC', RankedPosition(4)),
+                ]),
+                # QF 2
+                (ARENA_B, MatchNumber(0)): OrderedDict([
+                    ('III', RankedPosition(1)),
+                    ('GGG', RankedPosition(2)),
+                    ('FFF', RankedPosition(3)),
+                    ('DDD', RankedPosition(4)),
+                ]),
+            },
+        )
+
+    def test_two_teams_before(self) -> None:
+        league_matches = [{ARENA_A: build_match(arena=ARENA_A)}]
+
+        expected = build_5_matches(
+            places=[[UNKNOWABLE_TEAM] * 2] * 5,
+            first_match_number=1,
+        )
+
+        self.assertMatches(
+            expected,
+            structure_data=get_two_team_structure(),
+            matches=league_matches,
+        )
+
+    def test_two_teams_start(self) -> None:
+        expected_matches = build_5_matches([
+            ['CCC', 'EEE'],
+            ['DDD', 'FFF'],
+            ['AAA', UNKNOWABLE_TEAM],
+            ['BBB', UNKNOWABLE_TEAM],
+            [UNKNOWABLE_TEAM] * 2,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=get_two_team_structure(),
+        )
+
+    def test_two_teams_partial_1(self) -> None:
+        expected_matches = build_5_matches([
+            ['CCC', 'EEE'],
+            ['DDD', 'FFF'],
+            ['AAA', 'EEE'],
+            ['BBB', UNKNOWABLE_TEAM],
+            [UNKNOWABLE_TEAM] * 2,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=get_two_team_structure(),
+            knockout_positions={
+                # QF 1
+                (ARENA_A, MatchNumber(0)): OrderedDict([
+                    ('EEE', RankedPosition(1)),
+                    ('CCC', RankedPosition(2)),
+                ]),
+            },
+        )
+
+    def test_two_teams_partial_2(self) -> None:
+        expected_matches = build_5_matches([
+            ['CCC', 'EEE'],
+            ['DDD', 'FFF'],
+            ['AAA', 'EEE'],
+            ['BBB', 'DDD'],
+            [UNKNOWABLE_TEAM] * 2,
+        ])
+
+        self.assertMatches(
+            expected_matches,
+            structure_data=get_two_team_structure(),
+            knockout_positions={
+                # QF 1
+                (ARENA_A, MatchNumber(0)): OrderedDict([
+                    ('EEE', RankedPosition(1)),
+                    ('CCC', RankedPosition(2)),
+                ]),
+                # QF 2
+                (ARENA_B, MatchNumber(0)): OrderedDict([
+                    ('DDD', RankedPosition(1)),
+                    ('FFF', RankedPosition(2)),
+                ]),
+            },
+        )
+
+    def test_invalid_position_reference(self) -> None:
+        self.assertInvalidReference(
+            _team_ref(round=0, slot=0, arena=ARENA_A, position=5),
+        )
+
+    def test_invalid_arena_reference_no_such_arena(self) -> None:
+        self.assertInvalidReference(
+            _team_ref(round=0, slot=0, arena=ArenaName('Missing'), position=0),
+        )
+
+    def test_invalid_arena_reference_not_used(self) -> None:
+        self.assertInvalidReference(
+            _team_ref(round=2, slot=0, arena=ARENA_B, position=0),
+        )
+
+    def test_invalid_slot_reference(self) -> None:
+        self.assertInvalidReference(
+            _team_ref(round=0, slot=5, arena=ARENA_A, position=0),
+        )
+
+    def test_invalid_round_reference(self) -> None:
+        self.assertInvalidReference(
+            _team_ref(round=5, slot=0, arena=ARENA_A, position=0),
+        )
+
+    def test_invalid_seed_reference_low(self) -> None:
+        self.assertInvalidSeed({'seed': 0})
+
+    def test_invalid_seed_reference_high(self) -> None:
+        self.assertInvalidSeed({'seed': 9999})
+
+    def test_invalid_position_reference_incomplete_league(self) -> None:
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{ARENA_A: build_match(arena=ARENA_A)}]
+        self.assertInvalidReference(
+            _team_ref(round=0, slot=0, arena=ARENA_A, position=5),
+            matches=league_matches,
+        )
+
+    def test_invalid_match_reference_incomplete_league(self) -> None:
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{ARENA_A: build_match(arena=ARENA_A)}]
+        self.assertInvalidReference(
+            _team_ref(round=0, slot=5, arena=ARENA_A, position=5),
+            matches=league_matches,
+        )
+
+    def test_invalid_round_reference_incomplete_league(self) -> None:
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{ARENA_A: build_match(arena=ARENA_A)}]
+        self.assertInvalidReference(
+            _team_ref(round=5, slot=0, arena=ARENA_A, position=5),
+            matches=league_matches,
+        )
+
+    def test_invalid_seed_reference_low_incomplete_league(self) -> None:
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{ARENA_A: build_match(arena=ARENA_A)}]
+        self.assertInvalidSeed({'seed': 0}, matches=league_matches)
+
+    def test_invalid_seed_reference_high_incomplete_league(self) -> None:
+        # Add an un-scored league match so that we don't appear to have played them all
+        league_matches = [{ARENA_A: build_match(arena=ARENA_A)}]
+        self.assertInvalidSeed({'seed': 9999}, matches=league_matches)
+
+    def test_too_few_teams_first_round(self) -> None:
+        n_teams, config = get_four_team_structure()
+
+        config['rounds'][0]['match_slots'][0][ARENA_A]['teams'].pop()
+
+        self.assertInvalidSchedule(n_teams, config, WrongNumberOfTeamsError)
+
+    def test_too_few_teams_second_round(self) -> None:
+        n_teams, config = get_four_team_structure()
+
+        config['rounds'][1]['match_slots'][0][ARENA_A]['teams'].pop()
+
+        self.assertInvalidSchedule(n_teams, config, WrongNumberOfTeamsError)
+
+    def test_too_few_teams_third_round(self) -> None:
+        n_teams, config = get_four_team_structure()
+
+        config['rounds'][2]['match_slots'][0][ARENA_A]['teams'].pop()
+
+        self.assertInvalidSchedule(n_teams, config, WrongNumberOfTeamsError)
+
+    def test_too_many_teams_first_round(self) -> None:
+        n_teams, config = get_four_team_structure()
+
+        config['rounds'][0]['match_slots'][0][ARENA_A]['teams'].append({'seed': 1})
+
+        self.assertInvalidSchedule(n_teams, config, WrongNumberOfTeamsError)
+
+    def test_too_many_teams_second_round(self) -> None:
+        n_teams, config = get_four_team_structure()
+
+        config['rounds'][1]['match_slots'][0][ARENA_A]['teams'].append({'seed': 1})
+
+        self.assertInvalidSchedule(n_teams, config, WrongNumberOfTeamsError)
+
+    def test_too_many_teams_third_round(self) -> None:
+        n_teams, config = get_four_team_structure()
+
+        config['rounds'][2]['match_slots'][0][ARENA_A]['teams'].append({'seed': 1})
+
+        self.assertInvalidSchedule(n_teams, config, WrongNumberOfTeamsError)

--- a/tests/test_structured_knockout_scheduler.py
+++ b/tests/test_structured_knockout_scheduler.py
@@ -774,3 +774,100 @@ class StaticKnockoutSchedulerTests(unittest.TestCase):
         config['rounds'][2]['match_slots'][0][ARENA_A]['teams'].append({'seed': 1})
 
         self.assertInvalidSchedule(n_teams, config, WrongNumberOfTeamsError)
+
+    def test_timings_no_delays(self) -> None:
+        scheduler = get_scheduler(get_four_team_structure())
+        scheduler.add_knockouts()
+
+        knockout_rounds = scheduler.knockout_rounds
+        num_rounds = len(knockout_rounds)
+
+        self.assertEqual(3, num_rounds, "Should be quarters, semis and finals")
+
+        start_times = [m[ARENA_A].start_time for m in scheduler.period.matches]
+
+        expected_times = [
+            # Quarter finals
+            datetime(2014, 4, 27, 14, 30),
+
+            # 5 minute gap
+
+            # Semis
+            datetime(2014, 4, 27, 14, 40),
+            datetime(2014, 4, 27, 14, 45),
+
+            # 10 minute gap
+
+            # Final
+            datetime(2014, 4, 27, 15, 0),
+        ]
+
+        self.assertEqual(expected_times, start_times, "Wrong start times")
+
+    def test_timings_with_delays_later_absorbed(self) -> None:
+        delays = [
+            Delay(
+                time=datetime(2014, 4, 27, 14, 32),
+                delay=timedelta(minutes=2),
+            ),
+            Delay(
+                time=datetime(2014, 4, 27, 14, 43),
+                delay=timedelta(minutes=2),
+            ),
+        ]
+
+        scheduler = get_scheduler(
+            get_four_team_structure(),
+            delays=delays,
+        )
+        scheduler.add_knockouts()
+
+        knockout_rounds = scheduler.knockout_rounds
+        num_rounds = len(knockout_rounds)
+
+        self.assertEqual(3, num_rounds, "Should be quarters, semis and finals")
+
+        start_times = [m[ARENA_A].start_time for m in scheduler.period.matches]
+
+        expected_times = [
+            # Quarter finals
+            datetime(2014, 4, 27, 14, 30),
+
+            # 5 minute gap, no flex, delay carries
+
+            # Semis
+            datetime(2014, 4, 27, 14, 42),  # affected by first delay
+            datetime(2014, 4, 27, 14, 49),  # affected by both delays
+
+            # 10 minute gap, 5 minutes flex, all time recovered
+
+            # Final
+            datetime(2014, 4, 27, 15, 0),
+        ]
+
+        self.assertEqual(expected_times, start_times, "Wrong start times")
+
+        self.assertEqual(
+            [
+                Delay(
+                    time=datetime(2014, 4, 27, 14, 32),
+                    delay=timedelta(minutes=2),
+                ),
+                Delay(
+                    time=datetime(2014, 4, 27, 14, 43),
+                    delay=timedelta(minutes=2),
+                ),
+                Delay(
+                    time=datetime(2014, 4, 27, 14, 54),
+                    delay=timedelta(minutes=-4),
+                ),
+            ],
+            scheduler.schedule.delays,
+            "Should have updated the schedule with recovered time",
+        )
+
+        self.assertEqual(
+            timedelta(0),
+            sum((x.delay for x in scheduler.schedule.delays), start=timedelta(0)),
+            "Final delay should be zero",
+        )


### PR DESCRIPTION
This introduces a couple of new config formats:
- for specifying the round spacings in the automatic knockout scheduler, along with introducing a new (and preferable) means to specify which scheduler to use
- for specifying a knockout structure of rounds & matches without timings

Builds on https://github.com/PeterJCLaw/srcomp/pull/58.

Fixes https://github.com/PeterJCLaw/srcomp/issues/49

Suggest review by commit.